### PR TITLE
Fix UData::point test

### DIFF
--- a/Test/gsapTests/UDataTests.cpp
+++ b/Test/gsapTests/UDataTests.cpp
@@ -369,6 +369,7 @@ namespace TestUData {
         Assert::IsTrue(update1 > 0, "Time not updated on first insert");
         Assert::IsTrue(ud.valid(), "Not valid after first insert");
 
+        std::this_thread::sleep_for(std::chrono::milliseconds(10));
         ud.set(7.35);
         UData::size_type update2 = ud.updated();
         Assert::AreEqual(7.35, ud.get(VALUE), 1e-12, "Unexpected value using set");
@@ -393,7 +394,7 @@ namespace TestUData {
             ud.getPair();
             Assert::Fail("Got pair from UType::Point without throwing");
         }
-        catch (...) {
+        catch (const std::out_of_range&) {
         }
     }
 

--- a/Test/gsapTests/UDataTests.cpp
+++ b/Test/gsapTests/UDataTests.cpp
@@ -369,7 +369,7 @@ namespace TestUData {
         Assert::IsTrue(update1 > 0, "Time not updated on first insert");
         Assert::IsTrue(ud.valid(), "Not valid after first insert");
 
-        std::this_thread::sleep_for(std::chrono::milliseconds(10));
+        std::this_thread::sleep_for(std::chrono::milliseconds(1));
         ud.set(7.35);
         UData::size_type update2 = ud.updated();
         Assert::AreEqual(7.35, ud.get(VALUE), 1e-12, "Unexpected value using set");

--- a/inc/UData.h
+++ b/inc/UData.h
@@ -42,8 +42,8 @@ namespace PCOE {
         MeanCovar,
         Samples,
         WSamples,
-        Percentiles       = WSamples,
-        WeightedSamples   = WSamples,
+        Percentiles = WSamples,
+        WeightedSamples = WSamples,
         UnweightedSamples = Samples,
     };
 
@@ -74,7 +74,7 @@ namespace PCOE {
         struct Proxy;
         struct ConstProxy;
 
-        using clock      = std::chrono::steady_clock;
+        using clock = std::chrono::steady_clock;
         using time_point = clock::time_point;
         using time_ticks = time_point::rep;
 
@@ -83,8 +83,8 @@ namespace PCOE {
         using size_type = std::vector<double>::size_type;
 
         class iterator;
-        using const_iterator         = std::vector<double>::const_iterator;
-        using reverse_iterator       = std::vector<double>::reverse_iterator;
+        using const_iterator = std::vector<double>::const_iterator;
+        using reverse_iterator = std::vector<double>::reverse_iterator;
         using const_reverse_iterator = std::vector<double>::const_reverse_iterator;
 
         //*------------------------------*
@@ -193,7 +193,7 @@ namespace PCOE {
         /**
          * @brief Gets the time that the current object was last updated.
          */
-        inline size_type updated() const {
+        inline time_ticks updated() const {
             return m_updated;
         }
 


### PR DESCRIPTION
@julianvu, here's another one for you to review, since you pretty much own the tests. In particular, I vaguely remember running into this on other tests before. Can you recall anywhere else we have had to sleep to avoid failures from timestamps not updating, and if so is this consistent with what we did in those cases?