### PR TITLE
Added a cmake install of the header/binary files and the example.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -13,91 +13,25 @@ set(CMAKE_ARCHIVE_OUTPUT_DIRECTORY_RELEASE ${CMAKE_BINARY_DIR})
 set(CMAKE_LIBRARY_OUTPUT_DIRECTORY_RELEASE ${CMAKE_BINARY_DIR})
 set(CMAKE_RUNTIME_OUTPUT_DIRECTORY_RELEASE ${CMAKE_BINARY_DIR})
 
+set(GSAP_INSTALL_BIN_DIR bin)
+set(GSAP_INSTALL_LIB_DIR lib)
+set(GSAP_INSTALL_INCLUDE_DIR include)
+set(GSAP_INSTALL_EXAMPLE_DIR example)
+
+# This hootenanny is to give the user a better default value for the 
+# install path in the GUI window. It seems we can't do this directly
+# with SET for built-in variables like CMAKE_INSTALL_PREFIX. 
+set(INSTALL_DIRECTORY "${PROJECT_BINARY_DIR}/install" CACHE PATH
+    "Directory to install to.")
+set(CMAKE_INSTALL_PREFIX ${INSTALL_DIRECTORY} CACHE INTERNAL 
+    "Install path prefix, prepended onto install directories." FORCE)
+
 # Build option for enabling compiler and linker flags for gathering coverage data
 # In command line, set option this way:
 # cmake -DCoverage=ON <build folder>
 option(Coverage "Coverage" OFF)
 
-if(${CMAKE_CXX_COMPILER_ID} STREQUAL "Clang")
-    # -g:                Produce debugging information
-    # -O3:               Optimize as much as possible while remaning standards compliant
-    # -O0:               Disable optimizations
-    # -std:              Determine the language standard.
-    # -Wall:             Enables all the warnings about constructions that some users consider questionable
-    # -Wcast-qual:       Warn whenever a pointer is cast so as to remove a type qualifier from the target type
-    # -Werror:           Make all warnings into errors
-    # -Weffc++:          Warn about violations of some guidelines from Scott Meyers' Effective C++ (Note 2016-07-13: Currently removed because it warns about some things that are perfectly safe)
-    # -Wextra:           Enables some extra warning flags that are not enabled by -Wall
-    # -Wfloat-equal:     Warn if floating-point values are used in equality comparisons.
-    # -Wformat:          Check calls to printf and scanf, etc.
-    # -Winline:          Warn if a function that is declared as inline cannot be inlined
-    # -Wold-style-cast:  Warn on C-style casts
-    # -Wpedantic:        Issue all the warnings demanded by strict ISO C and ISO C++
-    # -Wshadow:          Warn whenever a local variable or type declaration shadows another variable, parameter, type, or class member
-    # -Wsign-conversion: Warn for implicit conversions that may change the sign of an integer value
-    # -Wswitch-default:  Warn whenever a switch statement does not have a default case.
-    # -Wno-unknown-pragmas: (2016-07-13) Temporarily added to disable warnings about #pragma unused
-    set(CMAKE_CXX_FLAGS "-std=c++11 -pthread")
-    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fstrict-aliasing")
-    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall -Wcast-qual -Wextra -Wfloat-equal")
-    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wformat -Wold-style-cast -Wpedantic -Wshadow")
-    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wsign-conversion -Wswitch-default -Wno-unknown-pragmas")
-    set(CMAKE_CXX_FLAGS_DEBUG "-g -O0 -Winline")
-    set(CMAKE_CXX_FLAGS_RELEASE "-O3 -Werror")
-elseif(${CMAKE_CXX_COMPILER_ID} STREQUAL "GNU")
-    # -g:                Produce debugging information
-    # -O3:               Optimize as much as possible while remaning standards compliant
-    # -Og:               Enable optimizations that don't interfere with debugging
-    # -std:              Determine the language standard.
-    # -Wall:             Enables all the warnings about constructions that some users consider questionable
-    # -Wcast-qual:       Warn whenever a pointer is cast so as to remove a type qualifier from the target type
-    # -Werror:           Make all warnings into errors
-    # -Weffc++:          Warn about violations of some guidelines from Scott Meyers' Effective C++ (Note 2016-07-13: Currently removed because it warns about some things that are perfectly safe)
-    # -Wextra:           Enables some extra warning flags that are not enabled by -Wall
-    # -Wfloat-equal:     Warn if floating-point values are used in equality comparisons.
-    # -Wformat:          Check calls to printf and scanf, etc.
-    # -Winline:          Warn if a function that is declared as inline cannot be inlined
-    # -Wold-style-cast:  Warn on C-style casts
-    # -Wpedantic:        Issue all the warnings demanded by strict ISO C and ISO C++
-    # -Wshadow:          Warn whenever a local variable or type declaration shadows another variable, parameter, type, or class member
-    # -Wsign-conversion: Warn for implicit conversions that may change the sign of an integer value
-    # -Wswitch-default:  Warn whenever a switch statement does not have a default case.
-    # -Wno-unknown-pragmas: (2016-07-13) Temporarily added to disable warnings about #pragma unused
-    set(CMAKE_CXX_FLAGS "-std=c++11 -pthread")
-    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fstrict-aliasing")
-    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall -Wcast-qual -Wextra -Wfloat-equal")
-    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wformat -Wold-style-cast -Wpedantic -Wshadow")
-    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wsign-conversion -Wswitch-default -Wno-unknown-pragmas")
-
-if(Coverage)
-    #    If coverage option enabled, set compiler and linker flags to gather coverage data
-    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fprofile-arcs -ftest-coverage")
-    set(CMAKE_EXE_LINKER_FLAGS "-lgcov")
-endif()
-
-    set(CMAKE_CXX_FLAGS_DEBUG "-g -Og -Winline")
-    set(CMAKE_CXX_FLAGS_RELEASE "-O3 -Werror")
-elseif(${CMAKE_CXX_COMPILER_ID} STREQUAL "MSVC")
-    # /EHsc: Specifies the model of exception handling.
-    # /GL:   Enables whole program optimization.
-    # /Gm:   Enables minimal rebuild.
-    # /GS:   Buffers security check.
-    # /MD:   Creates a multithreaded DLL using MSVCRT.lib.
-    # /MDd:  Creates a debug multithreaded DLL using MSVCRTD.lib.
-    # /O2:   Creates fast code.
-    # /Od:   Disables optimization.
-    # /Oi:   Generates intrinsic functions.
-    # /RTC1: Enables run-time error checking.
-    # /sdl:  Enables additional (Windows-specific) security features and warnings.
-    # /W4:   Sets which warning level to output.
-    # /wd:   Disable warning
-    # /Zi:   Generates complete debugging information.
-    set(CMAKE_CXX_FLAGS "/EHsc /GS /sdl- /W4 /wd\"4996\" /Zi")
-    set(CMAKE_CXX_FLAGS_DEBUG "/Gm /MDd /Od /RTC1")
-    set(CMAKE_CXX_FLAGS_RELEASE "/GL /Gm- /MD /O2 /Oi")
-else()
-    message(FATAL_ERROR "${CMAKE_CXX_COMPILER_ID} is not recognized.")
-endif()
+include(compiler_flags.cmake)
 
 # Check command line to see if OpenMP is to be used.
 option(UseOpenMP "UseOpenMP" FALSE)
@@ -219,3 +153,10 @@ add_library(gsap ${HEADERS} ${SRCS})
 
 add_subdirectory(${CMAKE_CURRENT_SOURCE_DIR}/Test/)
 add_subdirectory(${CMAKE_CURRENT_SOURCE_DIR}/example/)
+
+install(TARGETS gsap
+  LIBRARY DESTINATION ${GSAP_INSTALL_LIB_DIR}
+  ARCHIVE DESTINATION ${GSAP_INSTALL_LIB_DIR})
+install(FILES ${HEADERS} DESTINATION ${GSAP_INSTALL_INCLUDE_DIR})
+ 
+install(FILES compiler_flags.cmake DESTINATION ${GSAP_INSTALL_EXAMPLE_DIR} )

--- a/compiler_flags.cmake
+++ b/compiler_flags.cmake
@@ -1,0 +1,80 @@
+if(${CMAKE_CXX_COMPILER_ID} STREQUAL "Clang")
+    # -g:                Produce debugging information
+    # -O3:               Optimize as much as possible while remaning standards compliant
+    # -O0:               Disable optimizations
+    # -std:              Determine the language standard.
+    # -Wall:             Enables all the warnings about constructions that some users consider questionable
+    # -Wcast-qual:       Warn whenever a pointer is cast so as to remove a type qualifier from the target type
+    # -Werror:           Make all warnings into errors
+    # -Weffc++:          Warn about violations of some guidelines from Scott Meyers' Effective C++ (Note 2016-07-13: Currently removed because it warns about some things that are perfectly safe)
+    # -Wextra:           Enables some extra warning flags that are not enabled by -Wall
+    # -Wfloat-equal:     Warn if floating-point values are used in equality comparisons.
+    # -Wformat:          Check calls to printf and scanf, etc.
+    # -Winline:          Warn if a function that is declared as inline cannot be inlined
+    # -Wold-style-cast:  Warn on C-style casts
+    # -Wpedantic:        Issue all the warnings demanded by strict ISO C and ISO C++
+    # -Wshadow:          Warn whenever a local variable or type declaration shadows another variable, parameter, type, or class member
+    # -Wsign-conversion: Warn for implicit conversions that may change the sign of an integer value
+    # -Wswitch-default:  Warn whenever a switch statement does not have a default case.
+    # -Wno-unknown-pragmas: (2016-07-13) Temporarily added to disable warnings about #pragma unused
+    set(CMAKE_CXX_FLAGS "-std=c++11 -pthread")
+    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fstrict-aliasing")
+    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall -Wcast-qual -Wextra -Wfloat-equal")
+    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wformat -Wold-style-cast -Wpedantic -Wshadow")
+    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wsign-conversion -Wswitch-default -Wno-unknown-pragmas")
+    set(CMAKE_CXX_FLAGS_DEBUG "-g -O0 -Winline")
+    set(CMAKE_CXX_FLAGS_RELEASE "-O3 -Werror")
+elseif(${CMAKE_CXX_COMPILER_ID} STREQUAL "GNU")
+    # -g:                Produce debugging information
+    # -O3:               Optimize as much as possible while remaning standards compliant
+    # -Og:               Enable optimizations that don't interfere with debugging
+    # -std:              Determine the language standard.
+    # -Wall:             Enables all the warnings about constructions that some users consider questionable
+    # -Wcast-qual:       Warn whenever a pointer is cast so as to remove a type qualifier from the target type
+    # -Werror:           Make all warnings into errors
+    # -Weffc++:          Warn about violations of some guidelines from Scott Meyers' Effective C++ (Note 2016-07-13: Currently removed because it warns about some things that are perfectly safe)
+    # -Wextra:           Enables some extra warning flags that are not enabled by -Wall
+    # -Wfloat-equal:     Warn if floating-point values are used in equality comparisons.
+    # -Wformat:          Check calls to printf and scanf, etc.
+    # -Winline:          Warn if a function that is declared as inline cannot be inlined
+    # -Wold-style-cast:  Warn on C-style casts
+    # -Wpedantic:        Issue all the warnings demanded by strict ISO C and ISO C++
+    # -Wshadow:          Warn whenever a local variable or type declaration shadows another variable, parameter, type, or class member
+    # -Wsign-conversion: Warn for implicit conversions that may change the sign of an integer value
+    # -Wswitch-default:  Warn whenever a switch statement does not have a default case.
+    # -Wno-unknown-pragmas: (2016-07-13) Temporarily added to disable warnings about #pragma unused
+    set(CMAKE_CXX_FLAGS "-std=c++11 -pthread")
+    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fstrict-aliasing")
+    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall -Wcast-qual -Wextra -Wfloat-equal")
+    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wformat -Wold-style-cast -Wpedantic -Wshadow")
+    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wsign-conversion -Wswitch-default -Wno-unknown-pragmas")
+
+if(Coverage)
+    #    If coverage option enabled, set compiler and linker flags to gather coverage data
+    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fprofile-arcs -ftest-coverage")
+    set(CMAKE_EXE_LINKER_FLAGS "-lgcov")
+endif()
+
+    set(CMAKE_CXX_FLAGS_DEBUG "-g -Og -Winline")
+    set(CMAKE_CXX_FLAGS_RELEASE "-O3 -Werror")
+elseif(${CMAKE_CXX_COMPILER_ID} STREQUAL "MSVC")
+    # /EHsc: Specifies the model of exception handling.
+    # /GL:   Enables whole program optimization.
+    # /Gm:   Enables minimal rebuild.
+    # /GS:   Buffers security check.
+    # /MD:   Creates a multithreaded DLL using MSVCRT.lib.
+    # /MDd:  Creates a debug multithreaded DLL using MSVCRTD.lib.
+    # /O2:   Creates fast code.
+    # /Od:   Disables optimization.
+    # /Oi:   Generates intrinsic functions.
+    # /RTC1: Enables run-time error checking.
+    # /sdl:  Enables additional (Windows-specific) security features and warnings.
+    # /W4:   Sets which warning level to output.
+    # /wd:   Disable warning
+    # /Zi:   Generates complete debugging information.
+    set(CMAKE_CXX_FLAGS "/EHsc /GS /sdl- /W4 /wd\"4996\" /Zi")
+    set(CMAKE_CXX_FLAGS_DEBUG "/Gm /MDd /Od /RTC1")
+    set(CMAKE_CXX_FLAGS_RELEASE "/GL /Gm- /MD /O2 /Oi")
+else()
+    message(FATAL_ERROR "${CMAKE_CXX_COMPILER_ID} is not recognized.")
+endif()

--- a/example/CMakeLists.txt
+++ b/example/CMakeLists.txt
@@ -7,3 +7,8 @@ include_directories(${CMAKE_CURRENT_SOURCE_DIR})
 
 link_libraries(gsap)
 add_executable(example ${SRCS})
+
+install(FILES ${SRCS} DESTINATION ${GSAP_INSTALL_EXAMPLE_DIR} )
+install(DIRECTORY cfg data DESTINATION ${GSAP_INSTALL_EXAMPLE_DIR} )
+install(FILES install-CMakeLists.txt DESTINATION ${GSAP_INSTALL_EXAMPLE_DIR}
+  RENAME CMakeLists.txt)

--- a/example/install-CMakeLists.txt
+++ b/example/install-CMakeLists.txt
@@ -1,0 +1,15 @@
+# CMakeLists.txt file to be installed with the example, for building it
+# from the install location.
+
+project(GSAP_EXAMPLE)
+cmake_minimum_required(VERSION 3.0)
+
+include(compiler_flags.cmake)
+
+set(SRCS progMain.cpp)
+include_directories(${CMAKE_CURRENT_SOURCE_DIR}/../include)
+link_directories(${CMAKE_CURRENT_SOURCE_DIR}/../lib)
+
+
+add_executable(example ${SRCS})
+target_link_libraries(example gsap)


### PR DESCRIPTION
I did this for creating the binary install to check into the AOS repo. It copies all of the include files, lib files, and example files into a separate directory. I thought it would be useful in general. There are several parts to it:
- added install commands for the needed targets and files, for now I simply put in all headers
- moved the compile flags into a separate file that can be installed with the example, since compiling the example requires them
- made a separate CMakeLists.txt file in the example dir, which is what you would use to compile the example from the install dir