### PR TITLE
Streamline test output

### DIFF
--- a/Test/gsapTests/MatrixTests.cpp
+++ b/Test/gsapTests/MatrixTests.cpp
@@ -65,7 +65,7 @@ namespace TestMatrix {
         for (size_t i = 0; i < ITERATIONS; ++i) {
             std::size_t m = sdist(rng);
             std::size_t n = sdist(rng);
-            double v      = dist(rng);
+            double v = dist(rng);
             try {
                 Matrix matrix(m, n, v);
             }
@@ -117,7 +117,7 @@ namespace TestMatrix {
     void construct_copy() {
         std::size_t m = 5;
         std::size_t n = 10;
-        double v      = 7.0;
+        double v = 7.0;
 
         Matrix m1(m, n, v);
         Matrix m2(m1);
@@ -133,7 +133,7 @@ namespace TestMatrix {
     void construct_move() {
         std::size_t m = 5;
         std::size_t n = 10;
-        double v      = 7.0;
+        double v = 7.0;
 
         Matrix m1(m, n, v);
         Matrix m2(std::move(m1));
@@ -149,7 +149,7 @@ namespace TestMatrix {
     void operator_assign() {
         std::size_t m = 5;
         std::size_t n = 10;
-        double v      = 7.0;
+        double v = 7.0;
 
         Matrix m1(m, n, v);
         Matrix m2 = m1;
@@ -171,8 +171,8 @@ namespace TestMatrix {
             for (std::size_t j = 0; j < m; ++j) {
                 for (std::size_t k = 0; k < n; ++k) {
                     double tmp = dist(rng);
-                    m1[j][k]   = tmp;
-                    m2[j][k]   = tmp;
+                    m1[j][k] = tmp;
+                    m2[j][k] = tmp;
                 }
             }
             Assert::IsTrue(m1 == m2, "Matrices failed to compare as equal");
@@ -393,8 +393,8 @@ namespace TestMatrix {
                 Matrix c(m, 1);
                 for (std::size_t j = 0; j < m; ++j) {
                     values[j][k] = dist(rng);
-                    m1[j][k]     = values[j][k];
-                    c[j][0]      = values[j][k];
+                    m1[j][k] = values[j][k];
+                    c[j][0] = values[j][k];
                 }
                 m2.col(k, c);
             }
@@ -438,7 +438,7 @@ namespace TestMatrix {
                 std::vector<double> c;
                 for (std::size_t j = 0; j < m; ++j) {
                     values[j][k] = dist(rng);
-                    m1[j][k]     = values[j][k];
+                    m1[j][k] = values[j][k];
                     c.push_back(values[j][k]);
                 }
                 m2.col(k, c);
@@ -507,8 +507,8 @@ namespace TestMatrix {
                 Matrix r(1, n);
                 for (std::size_t k = 0; k < n; ++k) {
                     values[j][k] = dist(rng);
-                    m1[j][k]     = values[j][k];
-                    r[0][k]      = values[j][k];
+                    m1[j][k] = values[j][k];
+                    r[0][k] = values[j][k];
                 }
                 m2.row(j, r);
             }
@@ -552,7 +552,7 @@ namespace TestMatrix {
                 std::vector<double> r;
                 for (std::size_t k = 0; k < n; ++k) {
                     values[j][k] = dist(rng);
-                    m1[j][k]     = values[j][k];
+                    m1[j][k] = values[j][k];
                     r.push_back(values[j][k]);
                 }
                 m2.row(j, r);
@@ -955,9 +955,9 @@ namespace TestMatrix {
 
         double r = 0;
         for (size_t i = 0; i < m.rows(); i++) {
-            double f   = std::pow(-1.0, i) * m[i][0];
+            double f = std::pow(-1.0, i) * m[i][0];
             Matrix sub = m.submatrix(i, 0);
-            double d   = laplaceDeterminant(sub);
+            double d = laplaceDeterminant(sub);
             r += f * d;
         }
         return r;
@@ -975,12 +975,12 @@ namespace TestMatrix {
                 for (std::size_t a = 0; a < i; ++a) {
                     for (std::size_t b = 0; b < i; ++b) {
                         double d = dist(rng);
-                        m[a][b]  = d;
+                        m[a][b] = d;
                     }
                 }
                 double det1 = m.determinant();
                 double det2 = laplaceDeterminant(m);
-                double e    = std::abs((det1 + det2) / 2e8);
+                double e = std::abs((det1 + det2) / 2e8);
                 Assert::AreEqual(det1, det2, e, "Random determinants");
             }
             for (size_t j = 0; j < ITERATIONS * 2; j++) {
@@ -989,7 +989,7 @@ namespace TestMatrix {
                 for (std::size_t a = 0; a < i; ++a) {
                     for (std::size_t b = a; b < i; ++b) {
                         double d = dist(rng);
-                        m[a][b]  = d;
+                        m[a][b] = d;
                     }
                     for (std::size_t b = 0; b < a; ++b) {
                         m[b][a] = m[a][b];
@@ -997,7 +997,7 @@ namespace TestMatrix {
                 }
                 double det1 = m.determinant();
                 double det2 = laplaceDeterminant(m);
-                double e    = std::abs((det1 + det2) / 2e9);
+                double e = std::abs((det1 + det2) / 2e9);
                 Assert::AreEqual(det1, det2, e, "Symetric random determinants");
             }
         }
@@ -1202,8 +1202,9 @@ namespace TestMatrix {
 
         Matrix m2;
         try {
-            std::cout << m1 << std::endl;
-            std::cout << m2 << std::endl;
+            std::stringstream ss;
+            ss << m1 << std::endl;
+            ss << m2 << std::endl;
         }
         catch (...) {
             Assert::Fail("Exception occurred in left bitwise shift.");

--- a/Test/gsapTests/UDPSocketTests.cpp
+++ b/Test/gsapTests/UDPSocketTests.cpp
@@ -17,9 +17,9 @@ using namespace PCOE::Test;
 void testUDPCtor() {
     UDPSocket socket1 = UDPSocket(AF_INET, 55555);
     UDPSocket socket2 = UDPSocket(AF_INET, 55556);
-    sockaddr_in si    = {};
-    si.sin_family     = AF_INET;
-    si.sin_port       = htons(55557);
+    sockaddr_in si = {};
+    si.sin_family = AF_INET;
+    si.sin_port = htons(55557);
     UDPSocket socket3 = UDPSocket((struct sockaddr*)&si, sizeof(si));
     UDPSocket socket4 = UDPSocket("127.0.0.1", 55558);
     UDPSocket socket5 = std::move(socket4);
@@ -58,15 +58,15 @@ void testUDPCtor() {
 
 void testUDPSendandReceive() {
     size_t expectedByteSize = 30;
-    UDPSocket socket1       = UDPSocket(AF_INET, 55555);
-    UDPSocket socket2       = UDPSocket(AF_INET, 55556);
+    UDPSocket socket1 = UDPSocket(AF_INET, 55555);
+    UDPSocket socket2 = UDPSocket(AF_INET, 55556);
 
     char buffer[128] = "Hello. This is a test message.";
 
     socket1.Send(buffer, 30, "127.0.0.1", 55556);
 
     char buffer2[128] = {0};
-    size_t actual     = socket2.Receive(buffer2, 30);
+    size_t actual = socket2.Receive(buffer2, 30);
 
     Assert::AreEqual(expectedByteSize, actual, "Byte sizes are not the same.");
     Assert::IsTrue(strcmp(buffer, buffer2) == 0, "Buffers are not the same.");
@@ -79,10 +79,10 @@ void testUDPSendandReceive() {
     Assert::IsTrue(strcmp(buffer, buffer2) == 0, "Buffers are not the same.");
 
     unsigned short port = 55557;
-    sockaddr_in si      = {};
-    si.sin_family       = AF_INET;
-    si.sin_port         = htons(port);
-    UDPSocket socket3   = UDPSocket((struct sockaddr*)&si, sizeof(si));
+    sockaddr_in si = {};
+    si.sin_family = AF_INET;
+    si.sin_port = htons(port);
+    UDPSocket socket3 = UDPSocket((struct sockaddr*)&si, sizeof(si));
     socket1.Connect((struct sockaddr*)&si, sizeof(si));
     // socket1.Send(buffer, sizeof(buffer)/sizeof(buffer[0]), (struct sockaddr*)&si, sizeof(si));
 }
@@ -128,9 +128,9 @@ void testExceptionHandling() {
     }
 
     unsigned short port = 55555;
-    sockaddr_in addr    = {};
-    addr.sin_family     = AF_INET;
-    addr.sin_port       = htons(port);
+    sockaddr_in addr = {};
+    addr.sin_family = AF_INET;
+    addr.sin_port = htons(port);
     try {
         UDPSocket socket6 = UDPSocket((struct sockaddr*)&addr, sizeof(addr));
         Assert::Fail("Socket created using taken port.");
@@ -139,12 +139,11 @@ void testExceptionHandling() {
     }
 
     UDPSocket socketToReceive = UDPSocket(AF_INET, 60000);
-    char buffer[31]           = "Hello, this is a test message.";
+    char buffer[31] = "Hello, this is a test message.";
     socket1.Send(buffer, sizeof(buffer) / sizeof(buffer[0]), "127.0.0.1", 60000);
     std::this_thread::sleep_for(std::chrono::milliseconds(1));
     char buffer2[128];
     UDPSocket::size_type result = socketToReceive.Available();
-    std::cout << result << std::endl;
 #if !defined(_WIN32) && !defined(__APPLE__)
     Assert::AreEqual(31, result, "Bytes available to read is not same as bytes sent.");
 #else
@@ -156,9 +155,9 @@ void testExceptionHandling() {
                      result,
                      "Available() returns bytes even though no more bytes are being sent.");
 
-    port            = 55558;
+    port = 55558;
     addr.sin_family = AF_UNIX;
-    addr.sin_port   = htons(port);
+    addr.sin_port = htons(port);
     try {
         socket1.Connect((struct sockaddr*)&addr, sizeof(addr));
         Assert::Fail("Connected socket to socket with unsupported address family");
@@ -177,10 +176,10 @@ void testExceptionHandling() {
     catch (std::system_error&) {
     }
 
-    port            = 55556;
+    port = 55556;
     addr.sin_family = AF_INET;
-    addr.sin_port   = htons(port);
-    socket1         = UDPSocket(AF_INET);
+    addr.sin_port = htons(port);
+    socket1 = UDPSocket(AF_INET);
     socket1.Connect((struct sockaddr*)&addr, sizeof(addr));
     try {
         socketToReceive.Close();

--- a/Test/inc/Test.h
+++ b/Test/inc/Test.h
@@ -1,45 +1,45 @@
 /** @file  Test.h
-  * @brief A simple, robust and lightweight unit testing framework.
-  * @details
-  *      This file contains a classes to facilitate running unit test
-  *      functions. Any function that takes no arguments and has no return
-  *      value can be used as a test. Tests will fail if they throw or cause an
-  *      abort. The expectation is that tests will fail as the result of a
-  *      failed assertion using the @see{Assert} class, which throws
-  *      @see{AssertFailed} exceptions. Other exceptions and aborts are
-  *      reported as such and considered unexpected.
-  * @details
-  *      The general usage of this framework is as follows. First, a number of
-  *      unit tests are written that take no arguments and return nothing. The
-  *      test methods are expected to use the static methods of the
-  *      @see{Assert} class to evaluate the expected outcomes of the test.
-  * @details
-  *      With the test cases written, a new @see{TestContext} is created, and
-  *      tests are added to it. Once the tests are added, calling the Execute
-  *      method will run all of the tests, outputting the progress of the tests
-  *      to stdout or another std::ostream specified by calling SetOutput. The
-  *      number of failed tests is also reported by the return value of Execute
-  *      to allow for programatic action if some tests fail.
-  *
-  * @example
-  *      #include <cstdlib>
-  *      #include "Test.h"
-  *      using namespace PCOE::Test;
-  *      void alway_pass() { } // Any test that doesn't throw or abort passes
-  *      void alway_fail() { Assert::Fail(); }
-  *      void abort_fail() { std::abort(); } // Fails, but doesn't crash
-  *      int main() {
-  *          TestContext tests;
-  *          tests.AddTest("Pass", always_pass);
-  *          tests.AddTest("Fail", alway_fail);
-  *          tests.AddTest("Abort", abort_fail);
-  *          return tests.Execute();
-  *      }
-  *
-  * @copyright Copyright (c) 2018 United States Government as represented by
-  *            the Administrator of the National Aeronautics and Space
-  *            Administration. All Rights Reserved.
-  */
+ * @brief A simple, robust and lightweight unit testing framework.
+ * @details
+ *      This file contains a classes to facilitate running unit test
+ *      functions. Any function that takes no arguments and has no return
+ *      value can be used as a test. Tests will fail if they throw or cause an
+ *      abort. The expectation is that tests will fail as the result of a
+ *      failed assertion using the @see{Assert} class, which throws
+ *      @see{AssertFailed} exceptions. Other exceptions and aborts are
+ *      reported as such and considered unexpected.
+ * @details
+ *      The general usage of this framework is as follows. First, a number of
+ *      unit tests are written that take no arguments and return nothing. The
+ *      test methods are expected to use the static methods of the
+ *      @see{Assert} class to evaluate the expected outcomes of the test.
+ * @details
+ *      With the test cases written, a new @see{TestContext} is created, and
+ *      tests are added to it. Once the tests are added, calling the Execute
+ *      method will run all of the tests, outputting the progress of the tests
+ *      to stdout or another std::ostream specified by calling SetOutput. The
+ *      number of failed tests is also reported by the return value of Execute
+ *      to allow for programatic action if some tests fail.
+ *
+ * @example
+ *      #include <cstdlib>
+ *      #include "Test.h"
+ *      using namespace PCOE::Test;
+ *      void alway_pass() { } // Any test that doesn't throw or abort passes
+ *      void alway_fail() { Assert::Fail(); }
+ *      void abort_fail() { std::abort(); } // Fails, but doesn't crash
+ *      int main() {
+ *          TestContext tests;
+ *          tests.AddTest("Pass", always_pass);
+ *          tests.AddTest("Fail", alway_fail);
+ *          tests.AddTest("Abort", abort_fail);
+ *          return tests.Execute();
+ *      }
+ *
+ * @copyright Copyright (c) 2018 United States Government as represented by
+ *            the Administrator of the National Aeronautics and Space
+ *            Administration. All Rights Reserved.
+ */
 
 #ifndef PCOE_TEST_H
 #define PCOE_TEST_H
@@ -57,17 +57,16 @@
 namespace PCOE {
     namespace Test {
         /** @brief An exception to be thrown when a unit test assertion fails.
-          *
-          * @author  Jason Watkins <jason-watkins@outlook.com>
-          * @version 1.0.0
-          * @date    2016-07-13
-          */
+         *
+         * @author  Jason Watkins <jason-watkins@outlook.com>
+         * @version 1.0.0
+         * @date    2016-07-13
+         */
         class AssertFailed : public std::exception {
         public:
             AssertFailed() {}
 
-            explicit AssertFailed(const std::string& what_msg)
-                : message(what_msg) { }
+            explicit AssertFailed(const std::string& what_msg) : message(what_msg) {}
 
             const char* what() const noexcept override {
                 return message.c_str();
@@ -78,45 +77,46 @@ namespace PCOE {
         };
 
         /** @brief Verifies conditions in unit tests using true/false propositions.
-          *
-          * @author  Jason Watkins <jason-watkins@outlook.com>
-          * @version 1.0.0
-          * @date    2016-07-13
-          */
+         *
+         * @author  Jason Watkins <jason-watkins@outlook.com>
+         * @version 1.0.0
+         * @date    2016-07-13
+         */
         class Assert {
         public:
             /** @brief Verifies that two specified generic type data are equal
-              *        by using the equality operator. The assertion fails if
-              *        they are not equal.
-              *
-              * @param expected The value that the unit test expects.
-              * @param acutal   The value that the unit test produced.
-              * @param message  A message to be displayed if the unit test
-              *                   fails.
-              * @expection AssertionFailed If the assertion fails.
-              */
-            template<typename T>
-            static void AreEqual(const T& expected, const T& actual,
-                const std::string& message = "") {
+             *        by using the equality operator. The assertion fails if
+             *        they are not equal.
+             *
+             * @param expected The value that the unit test expects.
+             * @param acutal   The value that the unit test produced.
+             * @param message  A message to be displayed if the unit test
+             *                   fails.
+             * @expection AssertionFailed If the assertion fails.
+             */
+            template <typename T>
+            static void AreEqual(const T& expected,
+                                 const T& actual,
+                                 const std::string& message = "") {
                 if (!(actual == expected)) {
                     throw AssertFailed(message);
                 }
             }
 
             /** @brief Verifies that two specified generic type data are equal
-              *        by using the equality operator. The assertion fails if
-              *        they are not equal.
-              *
-              * @param expected The value that the unit test expects.
-              * @param acutal   The value that the unit test produced.
-              * @param message  A message to be displayed if the unit test
-              *                   fails.
-              * @expection AssertionFailed If the assertion fails.
-              */
-            template<typename TExpected, typename TActual>
+             *        by using the equality operator. The assertion fails if
+             *        they are not equal.
+             *
+             * @param expected The value that the unit test expects.
+             * @param acutal   The value that the unit test produced.
+             * @param message  A message to be displayed if the unit test
+             *                   fails.
+             * @expection AssertionFailed If the assertion fails.
+             */
+            template <typename TExpected, typename TActual>
             static void AreEqual(const TExpected& expected,
-                const TActual& actual,
-                const std::string& message = "") {
+                                 const TActual& actual,
+                                 const std::string& message = "") {
                 TActual tmp = static_cast<TActual>(expected);
                 if (!(actual == tmp)) {
                     throw AssertFailed(message);
@@ -124,63 +124,68 @@ namespace PCOE {
             }
 
             /** @brief Verifies that two specified generic type data are almost
-              *        equal by comparing the magnitude of the difference
-              *        between @p{expected} and @p{actual} to @p{delta}.
-              *        The assertion fails if the magnitude of the difference
-              *        is greater than @p{delta}.
-              *
-              * @param expected The value that the unit test expects.
-              * @param acutal   The value that the unit test produced.
-              * @param delta    The maximum difference in magnitude.
-              * @param message  A message to be displayed if the unit test
-              *                 fails.
-              * @expection AssertionFailed If the assertion fails.
-              */
-            template<typename T>
-            static void AreEqual(const T& expected, const T& actual,
-                const T& delta, const std::string& message = "") {
+             *        equal by comparing the magnitude of the difference
+             *        between @p{expected} and @p{actual} to @p{delta}.
+             *        The assertion fails if the magnitude of the difference
+             *        is greater than @p{delta}.
+             *
+             * @param expected The value that the unit test expects.
+             * @param acutal   The value that the unit test produced.
+             * @param delta    The maximum difference in magnitude.
+             * @param message  A message to be displayed if the unit test
+             *                 fails.
+             * @expection AssertionFailed If the assertion fails.
+             */
+            template <typename T>
+            static void AreEqual(const T& expected,
+                                 const T& actual,
+                                 const T& delta,
+                                 const std::string& message = "") {
                 if (std::abs(actual - expected) > delta) {
                     throw AssertFailed(message);
                 }
             }
 
             /** @brief Verifies that two specified doubles are almost
-              *        equal by comparing the magnitude of the difference
-              *        between @p{expected} and @p{actual} to @p{delta}.
-              *        The assertion fails if the magnitude of the difference
-              *        is greater than @p{delta}.
-              *
-              * @param expected The value that the unit test expects.
-              * @param acutal   The value that the unit test produced.
-              * @param delta    The maximum difference in magnitude.
-              * @param message  A message to be displayed if the unit test
-              *                 fails.
-              * @expection AssertionFailed If the assertion fails.
-              */
-            static void AreEqual(double expected, double actual,
-                double delta, const std::string& message = "") {
+             *        equal by comparing the magnitude of the difference
+             *        between @p{expected} and @p{actual} to @p{delta}.
+             *        The assertion fails if the magnitude of the difference
+             *        is greater than @p{delta}.
+             *
+             * @param expected The value that the unit test expects.
+             * @param acutal   The value that the unit test produced.
+             * @param delta    The maximum difference in magnitude.
+             * @param message  A message to be displayed if the unit test
+             *                 fails.
+             * @expection AssertionFailed If the assertion fails.
+             */
+            static void AreEqual(double expected,
+                                 double actual,
+                                 double delta,
+                                 const std::string& message = "") {
                 if (std::abs(actual - expected) > delta) {
                     throw AssertFailed(message);
                 }
             }
 
             /** @brief Verifies that two specified generic type data are almost
-              *        equal by comparing the magnitude of the difference
-              *        between @p{expected} and @p{actual} to @p{delta}.
-              *        The assertion fails if the magnitude of the difference
-              *        is greater than @p{delta}.
-              *
-              * @param expected The value that the unit test expects.
-              * @param acutal   The value that the unit test produced.
-              * @param delta    The maximum difference in magnitude.
-              * @param message  A message to be displayed if the unit test
-              *                 fails.
-              * @expection AssertionFailed If the assertion fails.
-              */
-            template<typename TExpected, typename TActual>
+             *        equal by comparing the magnitude of the difference
+             *        between @p{expected} and @p{actual} to @p{delta}.
+             *        The assertion fails if the magnitude of the difference
+             *        is greater than @p{delta}.
+             *
+             * @param expected The value that the unit test expects.
+             * @param acutal   The value that the unit test produced.
+             * @param delta    The maximum difference in magnitude.
+             * @param message  A message to be displayed if the unit test
+             *                 fails.
+             * @expection AssertionFailed If the assertion fails.
+             */
+            template <typename TExpected, typename TActual>
             static void AreEqual(const TExpected& expected,
-                const TActual& actual, const TActual& delta,
-                const std::string& message = "") {
+                                 const TActual& actual,
+                                 const TActual& delta,
+                                 const std::string& message = "") {
                 TActual tmp = static_cast<TActual>(expected);
                 if (std::abs(actual - tmp) > delta) {
                     throw AssertFailed(message);
@@ -188,37 +193,38 @@ namespace PCOE {
             }
 
             /** @brief Verifies that two specified generic type data are not
-              *          equal by using the not equal operator. The assertion
-              *          fails if they are equal.
-              *
-              * @param notExpected The value that the unit test expects.
-              * @param acutal      The value that the unit test produced.
-              * @param message     A message to be displayed if the unit test
-              *                    fails.
-              * @expection AssertionFailed If the assertion fails.
-              */
-            template<typename T>
-            static void AreNotEqual(const T& notExpected, const T& actual,
-                const std::string& message = "") {
+             *          equal by using the not equal operator. The assertion
+             *          fails if they are equal.
+             *
+             * @param notExpected The value that the unit test expects.
+             * @param acutal      The value that the unit test produced.
+             * @param message     A message to be displayed if the unit test
+             *                    fails.
+             * @expection AssertionFailed If the assertion fails.
+             */
+            template <typename T>
+            static void AreNotEqual(const T& notExpected,
+                                    const T& actual,
+                                    const std::string& message = "") {
                 if (!(actual != notExpected)) {
                     throw AssertFailed(message);
                 }
             }
 
             /** @brief Verifies that two specified generic type data are not
-              *        equal by using the equality operator. The assertion
-              *        fails if they are not equal.
-              *
-              * @param notExpected The value that the unit test expects.
-              * @param acutal      The value that the unit test produced.
-              * @param message     A message to be displayed if the unit test
-              *                    fails.
-              * @expection AssertionFailed If the assertion fails.
-              */
-            template<typename TExpected, typename TActual>
+             *        equal by using the equality operator. The assertion
+             *        fails if they are not equal.
+             *
+             * @param notExpected The value that the unit test expects.
+             * @param acutal      The value that the unit test produced.
+             * @param message     A message to be displayed if the unit test
+             *                    fails.
+             * @expection AssertionFailed If the assertion fails.
+             */
+            template <typename TExpected, typename TActual>
             static void AreNotEqual(const TExpected& notExpected,
-                const TActual& actual,
-                const std::string& message = "") {
+                                    const TActual& actual,
+                                    const std::string& message = "") {
                 TActual tmp = static_cast<TActual>(notExpected);
                 if (!(actual == tmp)) {
                     throw AssertFailed(message);
@@ -226,63 +232,68 @@ namespace PCOE {
             }
 
             /** @brief Verifies that two specified generic type data are not
-              *        almost equal by comparing the magnitude of the
-              *        difference between @p{expected} and @p{actual} to
-              *        @p{delta}. The assertion fails if the magnitude of
-              *        the difference is less than or equal to @p{delta}.
-              *
-              * @param notExpected The value that the unit test expects.
-              * @param acutal      The value that the unit test produced.
-              * @param delta       The minimum difference in magnitude.
-              * @param message      A message to be displayed if the unit test
-              *                     fails.
-              * @expection AssertionFailed If the assertion fails.
-              */
-            template<typename T>
-            static void AreNotEqual(const T& notExpected, const T& actual,
-                const T& delta, const std::string& message = "") {
+             *        almost equal by comparing the magnitude of the
+             *        difference between @p{expected} and @p{actual} to
+             *        @p{delta}. The assertion fails if the magnitude of
+             *        the difference is less than or equal to @p{delta}.
+             *
+             * @param notExpected The value that the unit test expects.
+             * @param acutal      The value that the unit test produced.
+             * @param delta       The minimum difference in magnitude.
+             * @param message      A message to be displayed if the unit test
+             *                     fails.
+             * @expection AssertionFailed If the assertion fails.
+             */
+            template <typename T>
+            static void AreNotEqual(const T& notExpected,
+                                    const T& actual,
+                                    const T& delta,
+                                    const std::string& message = "") {
                 if (std::abs(actual - notExpected) <= delta) {
                     throw AssertFailed(message);
                 }
             }
 
             /** @brief Verifies that two specified doubles are almost
-              *        equal by comparing the magnitude of the difference
-              *        between @p{expected} and @p{actual} to @p{delta}.
-              *        The assertion fails if the magnitude of the difference
-              *        is greater than @p{delta}.
-              *
-              * @param notExpected The value that the unit test expects.
-              * @param acutal      The value that the unit test produced.
-              * @param delta       The maximum difference in magnitude.
-              * @param message     A message to be displayed if the unit test
-              *                    fails.
-              * @expection AssertionFailed If the assertion fails.
-              */
-            static void AreNotEqual(double notExpected, double actual,
-                double delta, const std::string& message = "") {
+             *        equal by comparing the magnitude of the difference
+             *        between @p{expected} and @p{actual} to @p{delta}.
+             *        The assertion fails if the magnitude of the difference
+             *        is greater than @p{delta}.
+             *
+             * @param notExpected The value that the unit test expects.
+             * @param acutal      The value that the unit test produced.
+             * @param delta       The maximum difference in magnitude.
+             * @param message     A message to be displayed if the unit test
+             *                    fails.
+             * @expection AssertionFailed If the assertion fails.
+             */
+            static void AreNotEqual(double notExpected,
+                                    double actual,
+                                    double delta,
+                                    const std::string& message = "") {
                 if (std::abs(actual - notExpected) <= delta) {
                     throw AssertFailed(message);
                 }
             }
 
             /** @brief Verifies that two specified generic type data are not
-              *        almost equal by comparing the magnitude of the
-              *        difference between @p{expected} and @p{actual} to
-              *        @p{delta}. The assertion fails if the magnitude of
-              *        the difference is less than or equal to @p{delta}.
-              *
-              * @param notExpected The value that the unit test expects.
-              * @param acutal      The value that the unit test produced.
-              * @param delta       The minimum difference in magnitude.
-              * @param message     A message to be displayed if the unit test
-              *                    fails.
-              * @expection AssertionFailed If the assertion fails.
-              */
-            template<typename TExpected, typename TActual>
+             *        almost equal by comparing the magnitude of the
+             *        difference between @p{expected} and @p{actual} to
+             *        @p{delta}. The assertion fails if the magnitude of
+             *        the difference is less than or equal to @p{delta}.
+             *
+             * @param notExpected The value that the unit test expects.
+             * @param acutal      The value that the unit test produced.
+             * @param delta       The minimum difference in magnitude.
+             * @param message     A message to be displayed if the unit test
+             *                    fails.
+             * @expection AssertionFailed If the assertion fails.
+             */
+            template <typename TExpected, typename TActual>
             static void AreNotEqual(const TExpected& notExpected,
-                const TActual& actual, const TActual& delta,
-                const std::string& message = "") {
+                                    const TActual& actual,
+                                    const TActual& delta,
+                                    const std::string& message = "") {
                 TActual tmp = static_cast<TActual>(notExpected);
                 if (std::abs(actual - tmp) <= delta) {
                     throw AssertFailed(message);
@@ -290,18 +301,19 @@ namespace PCOE {
             }
 
             /** @brief Verifies that two pointers refer to the same memory
-              *        location. The assertion fails if they refer to different
-              *        memory locations.
-              *
-              * @param expected The value that the unit test expects.
-              * @param acutal   The value that the unit test produced.
-              * @param message  A message to be displayed if the unit test
-              *                 fails.
-              * @expection AssertionFailed If the assertion fails.
-              */
-            template<typename TExpected, typename TActual>
-            static void AreSame(const TExpected* expected, const TActual* actual,
-                const std::string& message = "") {
+             *        location. The assertion fails if they refer to different
+             *        memory locations.
+             *
+             * @param expected The value that the unit test expects.
+             * @param acutal   The value that the unit test produced.
+             * @param message  A message to be displayed if the unit test
+             *                 fails.
+             * @expection AssertionFailed If the assertion fails.
+             */
+            template <typename TExpected, typename TActual>
+            static void AreSame(const TExpected* expected,
+                                const TActual* actual,
+                                const std::string& message = "") {
                 void* a = static_cast<void*>(expected);
                 void* b = static_cast<void*>(actual);
                 if (a != b) {
@@ -310,18 +322,19 @@ namespace PCOE {
             }
 
             /** @brief Verifies that two pointers refer to different memory
-              *        locations. The assertion fails if they refer to the
-              *        same memory location.
-              *
-              * @param notExpected The value that the unit test expects.
-              * @param acutal      The value that the unit test produced.
-              * @param message     A message to be displayed if the unit test
-              *                    fails.
-              * @expection AssertionFailed If the assertion fails.
-              */
-            template<typename TExpected, typename TActual>
-            static void AreNotSame(const TExpected* expected, const TActual* actual,
-                const std::string& message = "") {
+             *        locations. The assertion fails if they refer to the
+             *        same memory location.
+             *
+             * @param notExpected The value that the unit test expects.
+             * @param acutal      The value that the unit test produced.
+             * @param message     A message to be displayed if the unit test
+             *                    fails.
+             * @expection AssertionFailed If the assertion fails.
+             */
+            template <typename TExpected, typename TActual>
+            static void AreNotSame(const TExpected* expected,
+                                   const TActual* actual,
+                                   const std::string& message = "") {
                 void* a = static_cast<void*>(expected);
                 void* b = static_cast<void*>(actual);
                 if (a == b) {
@@ -330,23 +343,22 @@ namespace PCOE {
             }
 
             /** @brief Fails without checking any conditions
-              *
-              * @param message  A message to be display.
-              * @expection AssertionFailed Always thrown.
-              */
-            [[noreturn]]
-            static void Fail(const std::string& message = "") {
+             *
+             * @param message  A message to be display.
+             * @expection AssertionFailed Always thrown.
+             */
+            [[noreturn]] static void Fail(const std::string& message = "") {
                 throw AssertFailed(message);
             }
 
             /** @brief Verifies that two specified condition is false. The
-              *        assertion fails if the condition is true.
-              *
-              * @param condition The condition to verify.
-              * @param message   A message to be displayed if the unit test
-              *                  fails.
-              * @expection AssertionFailed If the assertion fails.
-              */
+             *        assertion fails if the condition is true.
+             *
+             * @param condition The condition to verify.
+             * @param message   A message to be displayed if the unit test
+             *                  fails.
+             * @expection AssertionFailed If the assertion fails.
+             */
             static void IsFalse(bool condition, const std::string& message = "") {
                 if (condition) {
                     throw AssertFailed(message);
@@ -354,14 +366,14 @@ namespace PCOE {
             }
 
             /** @brief Verifies that the specified float value is not a
-              *        number using std::isnan. The assertion fails if
-              *        @p{value} is a valid number.
-              *
-              * @param value    The value to check.
-              * @param message  A message to be displayed if the unit test
-              *                 fails.
-              * @expection AssertionFailed If the assertion fails.
-              */
+             *        number using std::isnan. The assertion fails if
+             *        @p{value} is a valid number.
+             *
+             * @param value    The value to check.
+             * @param message  A message to be displayed if the unit test
+             *                 fails.
+             * @expection AssertionFailed If the assertion fails.
+             */
             static void IsNaN(float value, const std::string& message = "") {
                 if (!std::isnan(value)) {
                     throw AssertFailed(message);
@@ -369,14 +381,14 @@ namespace PCOE {
             }
 
             /** @brief Verifies that the specified double value is not a
-              *        number using std::isnan. The assertion fails if
-              *        @p{value} is a valid number.
-              *
-              * @param value    The value to check.
-              * @param message  A message to be displayed if the unit test
-              *                 fails.
-              * @expection AssertionFailed If the assertion fails.
-              */
+             *        number using std::isnan. The assertion fails if
+             *        @p{value} is a valid number.
+             *
+             * @param value    The value to check.
+             * @param message  A message to be displayed if the unit test
+             *                 fails.
+             * @expection AssertionFailed If the assertion fails.
+             */
             static void IsNaN(double value, const std::string& message = "") {
                 if (!std::isnan(value)) {
                     throw AssertFailed(message);
@@ -384,14 +396,14 @@ namespace PCOE {
             }
 
             /** @brief Verifies that the specified long double value is not a
-              *        number using std::isnan. The assertion fails if
-              *        @p{value} is a valid number.
-              *
-              * @param value    The value to check.
-              * @param message  A message to be displayed if the unit test
-              *                 fails.
-              * @expection AssertionFailed If the assertion fails.
-              */
+             *        number using std::isnan. The assertion fails if
+             *        @p{value} is a valid number.
+             *
+             * @param value    The value to check.
+             * @param message  A message to be displayed if the unit test
+             *                 fails.
+             * @expection AssertionFailed If the assertion fails.
+             */
             static void IsNaN(long double value, const std::string& message = "") {
                 if (!std::isnan(value)) {
                     throw AssertFailed(message);
@@ -399,14 +411,14 @@ namespace PCOE {
             }
 
             /** @brief Verifies that the specified pointer is null. The
-              *        assertion fails if it is not null.
-              *
-              * @param value    The value to check.
-              * @param message  A message to be displayed if the unit test
-              *                 fails.
-              * @expection AssertionFailed If the assertion fails.
-              */
-            template<typename T>
+             *        assertion fails if it is not null.
+             *
+             * @param value    The value to check.
+             * @param message  A message to be displayed if the unit test
+             *                 fails.
+             * @expection AssertionFailed If the assertion fails.
+             */
+            template <typename T>
             static void IsNull(const T* value, const std::string& message = "") {
                 if (value) {
                     throw AssertFailed(message);
@@ -414,30 +426,29 @@ namespace PCOE {
             }
 
             /** @brief Verifies that the specified value is not valid. The
-              *        assertion fails if it coerces to true.
-              *
-              * @param value    The value to check.
-              * @param message  A message to be displayed if the unit test
-              *                 fails.
-              * @expection AssertionFailed If the assertion fails.
-              */
-            template<typename T>
-            static void IsNull(const T& value,
-                const std::string& message = "") {
+             *        assertion fails if it coerces to true.
+             *
+             * @param value    The value to check.
+             * @param message  A message to be displayed if the unit test
+             *                 fails.
+             * @expection AssertionFailed If the assertion fails.
+             */
+            template <typename T>
+            static void IsNull(const T& value, const std::string& message = "") {
                 if (value) {
                     throw AssertFailed(message);
                 }
             }
 
             /** @brief Verifies that the specified pointer is not null. The
-              *        assertion fails if it is null.
-              *
-              * @param value    The value to check.
-              * @param message  A message to be displayed if the unit test
-              *                 fails.
-              * @expection AssertionFailed If the assertion fails.
-              */
-            template<typename T>
+             *        assertion fails if it is null.
+             *
+             * @param value    The value to check.
+             * @param message  A message to be displayed if the unit test
+             *                 fails.
+             * @expection AssertionFailed If the assertion fails.
+             */
+            template <typename T>
             static void IsNotNull(const T* value, const std::string& message = "") {
                 if (!value) {
                     throw AssertFailed(message);
@@ -445,29 +456,28 @@ namespace PCOE {
             }
 
             /** @brief Verifies that the specified value is valid. The
-            *          assertion fails if it coerces to false.
-            *
-            * @param value    The value to check.
-            * @param message  A message to be displayed if the unit test
-            *                 fails.
-            * @expection AssertionFailed If the assertion fails.
-            */
-            template<typename T>
-            static void IsNotNull(const T& value,
-                const std::string& message = "") {
+             *          assertion fails if it coerces to false.
+             *
+             * @param value    The value to check.
+             * @param message  A message to be displayed if the unit test
+             *                 fails.
+             * @expection AssertionFailed If the assertion fails.
+             */
+            template <typename T>
+            static void IsNotNull(const T& value, const std::string& message = "") {
                 if (!value) {
                     throw AssertFailed(message);
                 }
             }
 
             /** @brief Verifies that two specified condition is true. The
-              *        assertion fails if the condition is false.
-              *
-              * @param condition The condition to verify.
-              * @param message   A message to be displayed if the unit test
-              *                  fails.
-              * @expection AssertionFailed If the assertion fails.
-              */
+             *        assertion fails if the condition is false.
+             *
+             * @param condition The condition to verify.
+             * @param message   A message to be displayed if the unit test
+             *                  fails.
+             * @expection AssertionFailed If the assertion fails.
+             */
             static void IsTrue(bool condition, const std::string& message = "") {
                 if (!condition) {
                     throw AssertFailed(message);
@@ -490,68 +500,67 @@ namespace PCOE {
         };
 
         /** @brief Represents a harness for running unit tests.
-          *
-          *  @author  Jason Watkins <jason-watkins@outlook.com>
-          *  @version 1.0.0
-          *  @date    2016-07-13
-          */
+         *
+         *  @author  Jason Watkins <jason-watkins@outlook.com>
+         *  @version 1.0.0
+         *  @date    2016-07-13
+         */
         class TestContext {
             using clock = std::chrono::high_resolution_clock;
             using time_point = clock::time_point;
             using duration = clock::duration;
+
         public:
             using TestFunction = std::function<void(void)>;
 
             /** @brief Initializes a new TestContext. */
-            TestContext() : out(&std::cout) { }
+            TestContext() : out(&std::cout) {}
 
             /** @brief Adds a function that contains code that must be run
-              *        after all of the tests in the specified category have
-              *        run and to cleanup resources that are used by the tests.
-              *
-              * @param category The name of the category associated with the
-              *                 initializer.
-              * @param clean    A function to run.
-              */
-            void AddCategoryCleanup(const std::string& category,
-                const TestFunction& clean) {
+             *        after all of the tests in the specified category have
+             *        run and to cleanup resources that are used by the tests.
+             *
+             * @param category The name of the category associated with the
+             *                 initializer.
+             * @param clean    A function to run.
+             */
+            void AddCategoryCleanup(const std::string& category, const TestFunction& clean) {
                 cleanup[category] = clean;
             }
 
             /** @brief Adds a function that contains code that must be run
-              *        before any of the tests in the specified category have
-              *        run and to allocate resources to be used by the tests.
-              *
-              * @param category The name of the category associated with the
-              *                 initializer.
-              * @param init     A function to run.
-              */
-            void AddCategoryInitializer(const std::string& category,
-                const TestFunction& init) {
+             *        before any of the tests in the specified category have
+             *        run and to allocate resources to be used by the tests.
+             *
+             * @param category The name of the category associated with the
+             *                 initializer.
+             * @param init     A function to run.
+             */
+            void AddCategoryInitializer(const std::string& category, const TestFunction& init) {
                 initializers[category] = init;
             }
 
-
             /** @brief Adds a unit test to the specified category. If no
-              *        category is specified, the test is added to the empty
-              *        category.
-              *
-              * @param name     The name of the test. Names are printed along
-              *                 with pass/fail status when tests are executed.
-              * @param test     A unit test function.
-              * @param category The group of the unit test. Unit tests results
-              *                 are printed based on their group.
-              */
-            void AddTest(const std::string& name, const TestFunction& test,
-                const std::string& category = "") {
+             *        category is specified, the test is added to the empty
+             *        category.
+             *
+             * @param name     The name of the test. Names are printed along
+             *                 with pass/fail status when tests are executed.
+             * @param test     A unit test function.
+             * @param category The group of the unit test. Unit tests results
+             *                 are printed based on their group.
+             */
+            void AddTest(const std::string& name,
+                         const TestFunction& test,
+                         const std::string& category = "") {
                 NameTestPair ntp = std::make_pair(name, test);
                 tests[category].push_back(ntp);
             }
 
             /** @brief Executes the added unit tests.
-              *
-              * @returns The number of tests that failed.
-              */
+             *
+             * @returns The number of tests that failed.
+             */
             int Execute() {
                 std::ostream& rout = *out;
                 time_point startTime = clock::now();
@@ -559,7 +568,7 @@ namespace PCOE {
                     TestSuite ts;
                     ts.name = cat.first;
 
-                    rout << "Running " << cat.first << ":\n";
+                    rout << "Running " << cat.first << ": ";
                     time_point tsStart = clock::now();
                     try {
                         TestFunction& initializer = initializers[cat.first];
@@ -569,7 +578,7 @@ namespace PCOE {
                     }
                     catch (...) {
                         std::size_t s = cat.second.size();
-                        rout << "    Initializer failed. Skipping " << s << " tests.\n";
+                        rout << "Initializer failed. Skipping " << s << " tests.\n";
                         failed += s;
                         continue;
                     }
@@ -577,29 +586,24 @@ namespace PCOE {
                     for (const NameTestPair& ntp : cat.second) {
                         TestCase tc;
                         tc.name = ntp.first;
-                        rout << "    " << std::setw(20) << ntp.first << " -- ";
                         time_point tcStart = clock::now();
                         try {
                             ntp.second();
-                            rout << "PASSED\n";
                             tc.passed = true;
                         }
                         catch (const AssertFailed& ex) {
-                            rout << "FAILED (ASSERT: " << ex.what() << ")\n";
                             ++failed;
                             ++ts.failed;
                             tc.passed = false;
                             tc.failureMessage = std::string("Assert Failed: ") + ex.what();
                         }
                         catch (const std::exception& ex) {
-                            rout << "FAILED (ERROR! " << ex.what() << ")\n";
                             ++failed;
                             ++ts.failed;
                             tc.passed = false;
                             tc.failureMessage = std::string("Exception: ") + ex.what();
                         }
                         catch (...) {
-                            rout << "FAILED (ERROR! UNEXPECTED EXCEPTION)\n";
                             ++failed;
                             ++ts.failed;
                             tc.passed = false;
@@ -608,6 +612,22 @@ namespace PCOE {
                         duration tcTime = clock::now() - tcStart;
                         tc.time = std::chrono::duration_cast<std::chrono::microseconds>(tcTime);
                         ts.results.push_back(tc);
+                    }
+
+                    if (ts.failed == 0) {
+                        rout << "All passed." << std::endl;
+                    }
+                    else {
+                        rout << std::endl;
+                        for (const auto& tc : ts.results) {
+                            rout << "    " << tc.name << " -- ";
+                            if (tc.passed) {
+                                rout << "PASSED" << std::endl;
+                            }
+                            else {
+                                rout << "FAILED: " << tc.failureMessage << std::endl;
+                            }
+                        }
                     }
 
                     try {
@@ -629,23 +649,27 @@ namespace PCOE {
             }
 
             /** @brief Sets the stream to which results are printed.
-              *
-              * @param stream The stream to output to.
-              */
+             *
+             * @param stream The stream to output to.
+             */
             void SetOutput(std::ostream& stream) {
                 out = &stream;
             }
 
             void WriteJUnit(std::ostream& stream) {
                 stream << "<?xml version=\"1.0\" encoding=\"utf-8\" ?>\n";
-                stream << "<testsuites name=\"PCOE\" failures=\"" << failed << "\" time=\"" << usTos(time) << "\">\n";
+                stream << "<testsuites name=\"PCOE\" failures=\"" << failed << "\" time=\""
+                       << usTos(time) << "\">\n";
                 for (const auto& cat : results) {
-                    stream << "    <testsuite name=\"" << cat.name << "\" failures=\"" << cat.failed << "\" time=\"" << usTos(cat.time) << "\">\n";
+                    stream << "    <testsuite name=\"" << cat.name << "\" failures=\"" << cat.failed
+                           << "\" time=\"" << usTos(cat.time) << "\">\n";
                     for (const auto& test : cat.results) {
-                        stream << "        <testcase name=\"" << test.name << "\" time=\"" << usTos(test.time) << "\"";
+                        stream << "        <testcase name=\"" << test.name << "\" time=\""
+                               << usTos(test.time) << "\"";
                         if (!test.failureMessage.empty()) {
                             stream << ">\n";
-                            stream << "            <failure message=\"" << test.failureMessage << "\"/>\n";
+                            stream << "            <failure message=\"" << test.failureMessage
+                                   << "\"/>\n";
                             stream << "        </testcase>\n";
                         }
                         else {


### PR DESCRIPTION
Streamlines the test output by only outputting a single "all passed" message for groups that don't have any failing tests. Also removed some unnecessary prints to stdout by matrix and udp socket tests.