### PR TITLE
Async events

### DIFF
--- a/Test/RunTests.ps1
+++ b/Test/RunTests.ps1
@@ -1,14 +1,13 @@
 # Expect this script to be in the test subdirectory, moving up to cpp will make life easier
 Push-Location "$PSScriptRoot/..";
 
-# Delete bin to make sure we get a clean build, and make sure the build Directory exists
-if (Test-Path bin) {
-    Remove-Item -Recurse -Force bin;
-}
 if (!(Test-Path build)) {
     New-Item build -ItemType Directory;
 }
-New-Item bin/testresults -ItemType Directory -Force;
+if (!(Test-Path bin)) {
+    New-Item bin -ItemType Directory;
+    New-Item bin/testresults -ItemType Directory -Force;
+}
 
 Push-Location build;
 Write-Host "Running CMake." -ForegroundColor Yellow;

--- a/Test/gsapTests/Messages/MessageBusTests.cpp
+++ b/Test/gsapTests/Messages/MessageBusTests.cpp
@@ -1,6 +1,7 @@
 // Copyright (c) 2018 United States Government as represented by the
 // Administrator of the National Aeronautics and Space Administration.
 // All Rights Reserved.
+#include <thread>
 #include <utility>
 
 #include "Messages/IMessageProcessor.h"
@@ -32,6 +33,8 @@ public:
 };
 
 namespace MessageBusTests {
+    static const auto PUBLISH_DELAY = std::chrono::milliseconds(5);
+
     void constructor() {
         MessageBus bus; // Default construct without exception
     }
@@ -51,6 +54,7 @@ namespace MessageBusTests {
         bus.publish(std::shared_ptr<Message>(new TestMessage(MessageId::TestInput0, "test")));
         bus.publish(std::shared_ptr<Message>(new TestMessage(MessageId::TestInput1, "test")));
         bus.publish(std::shared_ptr<Message>(new TestMessage(MessageId::TestInput0, "Other")));
+        std::this_thread::sleep_for(std::chrono::milliseconds(PUBLISH_DELAY));
         Assert::AreEqual(2, consumer.msgCount, "Consumer got the wrong number of messages");
     }
 
@@ -63,6 +67,7 @@ namespace MessageBusTests {
         bus.publish(std::shared_ptr<Message>(new TestMessage(MessageId::TestInput0, "test")));
         bus.publish(std::shared_ptr<Message>(new TestMessage(MessageId::TestInput1, "test")));
         bus.publish(std::shared_ptr<Message>(new TestMessage(MessageId::TestInput0, "Other")));
+        std::this_thread::sleep_for(std::chrono::milliseconds(PUBLISH_DELAY));
         Assert::AreEqual(1, consumer.msgCount, "Consumer got the wrong number of messages");
     }
 
@@ -76,6 +81,7 @@ namespace MessageBusTests {
         bus.publish(std::shared_ptr<Message>(new TestMessage(MessageId::TestInput0, "test")));
         bus.publish(std::shared_ptr<Message>(new TestMessage(MessageId::TestInput1, "test")));
         bus.publish(std::shared_ptr<Message>(new TestMessage(MessageId::TestInput0, "Other")));
+        std::this_thread::sleep_for(std::chrono::milliseconds(PUBLISH_DELAY));
         Assert::AreEqual(2, consumer.msgCount, "Consumer got the wrong number of messages");
     }
 
@@ -88,6 +94,7 @@ namespace MessageBusTests {
         bus.publish(std::shared_ptr<Message>(new TestMessage(MessageId::TestInput0, "test")));
         bus.publish(std::shared_ptr<Message>(new TestMessage(MessageId::TestInput1, "test")));
         bus.publish(std::shared_ptr<Message>(new TestMessage(MessageId::TestInput0, "Other")));
+        std::this_thread::sleep_for(std::chrono::milliseconds(PUBLISH_DELAY));
         Assert::AreEqual(2, consumer.msgCount, "Consumer got the wrong number of messages");
 
         bus.unsubscribe(&consumer);
@@ -95,6 +102,7 @@ namespace MessageBusTests {
         bus.publish(std::shared_ptr<Message>(new TestMessage(MessageId::TestInput0, "test")));
         bus.publish(std::shared_ptr<Message>(new TestMessage(MessageId::TestInput1, "test")));
         bus.publish(std::shared_ptr<Message>(new TestMessage(MessageId::TestInput0, "Other")));
+        std::this_thread::sleep_for(std::chrono::milliseconds(PUBLISH_DELAY));
         Assert::AreEqual(2, consumer.msgCount, "Consumer got the wrong number of messages");
     }
 
@@ -108,6 +116,7 @@ namespace MessageBusTests {
         bus.publish(std::shared_ptr<Message>(new TestMessage(MessageId::TestInput0, "test")));
         bus.publish(std::shared_ptr<Message>(new TestMessage(MessageId::TestInput1, "test")));
         bus.publish(std::shared_ptr<Message>(new TestMessage(MessageId::TestInput0, "Other")));
+        std::this_thread::sleep_for(std::chrono::milliseconds(PUBLISH_DELAY));
         Assert::AreEqual(3, consumer.msgCount, "Consumer got the wrong number of messages");
 
         bus.unsubscribe(&consumer, "test");
@@ -115,6 +124,7 @@ namespace MessageBusTests {
         bus.publish(std::shared_ptr<Message>(new TestMessage(MessageId::TestInput0, "test")));
         bus.publish(std::shared_ptr<Message>(new TestMessage(MessageId::TestInput1, "test")));
         bus.publish(std::shared_ptr<Message>(new TestMessage(MessageId::TestInput0, "Other")));
+        std::this_thread::sleep_for(std::chrono::milliseconds(PUBLISH_DELAY));
         Assert::AreEqual(4, consumer.msgCount, "Consumer got the wrong number of messages");
     }
 }

--- a/Test/gsapTests/Messages/MessageWatcherTests.cpp
+++ b/Test/gsapTests/Messages/MessageWatcherTests.cpp
@@ -1,83 +1,99 @@
 // Copyright (c) 2018 United States Government as represented by the
 // Administrator of the National Aeronautics and Space Administration.
 // All Rights Reserved.
+#include <thread>
 #include <utility>
 
 #include "DynamicArray.h"
 #include "Messages/DoubleMessage.h"
 #include "Messages/MessageBus.h"
 #include "Messages/MessageWatcher.h"
+#include "MockClasses.h"
 #include "Test.h"
 
 using namespace PCOE;
 using namespace PCOE::Test;
 
 namespace MessageWatcherTests {
+    static const auto PUBLISH_DELAY = std::chrono::milliseconds(5);
+
     void constructor() {
         MessageBus bus;
         const std::string src = "test";
         const std::vector<MessageId> ids = {MessageId::TestInput0, MessageId::TestInput1};
         DynamicArray<double> values(ids.size());
 
-        MessageWatcher<DynamicArray<double>> watcher(bus, src, ids, values);
+        MessageWatcher<DynamicArray<double>> watcher(bus,
+                                                     src,
+                                                     ids,
+                                                     MessageId::ModelInputVector,
+                                                     values);
 
         try {
             DynamicArray<double> values2(ids.size() + 1);
-            MessageWatcher<DynamicArray<double>> watcher2(bus, src, ids, values2);
+            MessageWatcher<DynamicArray<double>> watcher2(bus,
+                                                          src,
+                                                          ids,
+                                                          MessageId::ModelInputVector,
+                                                          values2);
             Assert::Fail("No precondition check for matching id and value sizes");
         }
         catch (const AssertException&) {
         }
     }
 
-    void allPresent() {
+    void publish() {
         MessageBus bus;
         const std::string src = "test";
         const std::vector<MessageId> ids = {MessageId::TestInput0, MessageId::TestInput1};
+        MessageId resultId = MessageId::ModelInputVector;
+        MessageCounter counter(bus, src, resultId);
         std::vector<double> values(ids.size());
 
-        MessageWatcher<std::vector<double>> watcher(bus, src, ids, values);
+        MessageWatcher<std::vector<double>> watcher(bus, src, ids, resultId, values);
 
-        Assert::IsFalse(watcher.allPresent(), "No data");
+        Assert::AreEqual(0, counter.getCount(), "No data");
         bus.publish(std::shared_ptr<Message>(new DoubleMessage(MessageId::TestInput0, src, 0.0)));
-        Assert::IsFalse(watcher.allPresent(), "1 input");
+        std::this_thread::sleep_for(std::chrono::milliseconds(PUBLISH_DELAY));
+        Assert::AreEqual(0, counter.getCount(), "1 input");
         bus.publish(std::shared_ptr<Message>(new DoubleMessage(MessageId::TestInput1, src, 0.0)));
-        Assert::IsTrue(watcher.allPresent(), "Both inputs");
+        std::this_thread::sleep_for(std::chrono::milliseconds(PUBLISH_DELAY));
+        Assert::AreEqual(1, counter.getCount(), "Both inputs");
+
+        auto msg =
+            dynamic_cast<TemplateMessage<std::vector<double>>*>(counter.getLastMessage().get());
+        const auto& msgValues = msg->getValue();
+        Assert::AreEqual(2, msgValues.size(), "Watcher message size");
+        Assert::AreEqual(0.0, msgValues[0], 1e-15, "Watcher message value 0");
+        Assert::AreEqual(0.0, msgValues[1], 1e-15, "Watcher message value 1");
     }
 
-    void reset() {
+    void messageCount() {
         MessageBus bus;
         const std::string src = "test";
         const std::vector<MessageId> ids = {MessageId::TestInput0, MessageId::TestInput1};
+        MessageId resultId = MessageId::ModelInputVector;
+        MessageCounter counter(bus, src, resultId);
         std::vector<double> values(ids.size());
 
-        MessageWatcher<std::vector<double>> watcher(bus, src, ids, values);
+        MessageWatcher<std::vector<double>> watcher(bus, src, ids, resultId, values);
 
-        bus.publish(std::shared_ptr<Message>(new DoubleMessage(MessageId::TestInput0, src, 0.0)));
-        bus.publish(std::shared_ptr<Message>(new DoubleMessage(MessageId::TestInput1, src, 0.0)));
-        Assert::IsTrue(watcher.allPresent(), "All present");
+        Assert::AreEqual(0, counter.getCount(), "No data");
+        bus.publish(std::shared_ptr<Message>(new DoubleMessage(MessageId::TestInput0, src, 1.0)));
+        std::this_thread::sleep_for(std::chrono::milliseconds(PUBLISH_DELAY));
+        Assert::AreEqual(0, counter.getCount(), "Input0 first value");
+        bus.publish(std::shared_ptr<Message>(new DoubleMessage(MessageId::TestInput0, src, 2.0)));
+        std::this_thread::sleep_for(std::chrono::milliseconds(PUBLISH_DELAY));
+        Assert::AreEqual(0, counter.getCount(), "Input0 second value");
+        bus.publish(std::shared_ptr<Message>(new DoubleMessage(MessageId::TestInput1, src, 3.0)));
+        std::this_thread::sleep_for(std::chrono::milliseconds(PUBLISH_DELAY));
+        Assert::AreEqual(1, counter.getCount(), "1 message per complete set");
 
-        watcher.reset();
-        Assert::IsFalse(watcher.allPresent(), "After reset");
-        bus.publish(std::shared_ptr<Message>(new DoubleMessage(MessageId::TestInput0, src, 0.0)));
-        Assert::IsFalse(watcher.allPresent(), "1 input after reset");
-        bus.publish(std::shared_ptr<Message>(new DoubleMessage(MessageId::TestInput1, src, 0.0)));
-        Assert::IsTrue(watcher.allPresent(), "Both inputs after reset");
-    }
-
-    void getValues() {
-        MessageBus bus;
-        const std::string src = "test";
-        const std::vector<MessageId> ids = {MessageId::TestInput0, MessageId::TestInput1};
-        std::vector<double> values(ids.size());
-
-        MessageWatcher<std::vector<double>> watcher(bus, src, ids, values);
-        bus.publish(std::shared_ptr<Message>(new DoubleMessage(MessageId::TestInput0, src, 42.0)));
-        bus.publish(std::shared_ptr<Message>(new DoubleMessage(MessageId::TestInput1, src, 97.0)));
-        Assert::IsTrue(watcher.allPresent(), "All present");
-
-        const auto& watcherValues = watcher.getValues();
-        Assert::AreEqual(42.0, watcherValues[0], 1e-6, "Value 1");
-        Assert::AreEqual(97.0, watcherValues[1], 1e-6, "Value 2");
+        auto msg =
+            dynamic_cast<TemplateMessage<std::vector<double>>*>(counter.getLastMessage().get());
+        const auto& msgValues = msg->getValue();
+        Assert::AreEqual(2, msgValues.size(), "Watcher message size");
+        Assert::AreEqual(2.0, msgValues[0], 1e-15, "Watcher message value 0");
+        Assert::AreEqual(3.0, msgValues[1], 1e-15, "Watcher message value 1");
     }
 }

--- a/Test/gsapTests/Messages/MessageWatcherTests.h
+++ b/Test/gsapTests/Messages/MessageWatcherTests.h
@@ -5,9 +5,7 @@
 namespace MessageWatcherTests {
     void constructor();
 
-    void allPresent();
+    void publish();
 
-    void reset();
-
-    void getValues();
+    void messageCount();
 }

--- a/Test/gsapTests/Observers/EventDrivenObserverTests.cpp
+++ b/Test/gsapTests/Observers/EventDrivenObserverTests.cpp
@@ -1,8 +1,10 @@
 // Copyright (c) 2018 United States Government as represented by the
 // Administrator of the National Aeronautics and Space Administration.
 // All Rights Reserved.
+#include <thread>
 #include <utility>
 
+#include "Messages/DoubleMessage.h"
 #include "MockClasses.h"
 #include "Observers/EventDrivenObserver.h"
 #include "Test.h"
@@ -11,24 +13,7 @@ using namespace PCOE;
 using namespace PCOE::Test;
 
 namespace EventDrivenObserverTests {
-    class ObserverListener final : public IMessageProcessor {
-    public:
-        ObserverListener(MessageBus& bus, std::string src) : source(std::move(src)) {
-            bus.subscribe(this, source, MessageId::ModelStateEstimate);
-        }
-
-        void processMessage(const std::shared_ptr<Message>& message) override {
-            ++count;
-        }
-
-        inline std::size_t getCount() const {
-            return count;
-        }
-
-    private:
-        std::string source;
-        std::size_t count = 0;
-    };
+    static const auto PUBLISH_DELAY = std::chrono::milliseconds(5);
 
     void constructor() {
         MessageBus bus;
@@ -44,24 +29,30 @@ namespace EventDrivenObserverTests {
         TestModel tm;
         const std::string src = "test";
 
-        ObserverListener listener(bus, src);
+        MessageCounter listener(bus, src, MessageId::ModelStateEstimate);
         EventDrivenObserver edObs(bus, std::unique_ptr<Observer>(new TestObserver(&tm)), src);
 
         Assert::AreEqual(0, listener.getCount(), "obs produced state estimate on construction");
         bus.publish(std::shared_ptr<Message>(new DoubleMessage(MessageId::TestInput0, src, 0.0)));
+        std::this_thread::sleep_for(std::chrono::milliseconds(PUBLISH_DELAY));
         Assert::AreEqual(0, listener.getCount(), "obs produced state estimate before init (1)");
         bus.publish(std::shared_ptr<Message>(new DoubleMessage(MessageId::TestInput1, src, 0.0)));
+        std::this_thread::sleep_for(std::chrono::milliseconds(PUBLISH_DELAY));
         Assert::AreEqual(0, listener.getCount(), "obs produced state estimate before init (2)");
         bus.publish(std::shared_ptr<Message>(new DoubleMessage(MessageId::TestOutput0, src, 0.0)));
+        std::this_thread::sleep_for(std::chrono::milliseconds(PUBLISH_DELAY));
         Assert::AreEqual(0,
                          listener.getCount(),
                          "obs produced state estimate after first set of data");
 
         bus.publish(std::shared_ptr<Message>(new DoubleMessage(MessageId::TestInput0, src, 0.0)));
+        std::this_thread::sleep_for(std::chrono::milliseconds(PUBLISH_DELAY));
         Assert::AreEqual(0, listener.getCount(), "obs produced state estimate on 1 input");
         bus.publish(std::shared_ptr<Message>(new DoubleMessage(MessageId::TestInput1, src, 0.0)));
+        std::this_thread::sleep_for(std::chrono::milliseconds(PUBLISH_DELAY));
         Assert::AreEqual(0, listener.getCount(), "obs produced state estimate on 2 inputs");
         bus.publish(std::shared_ptr<Message>(new DoubleMessage(MessageId::TestOutput0, src, 0.0)));
+        std::this_thread::sleep_for(std::chrono::milliseconds(PUBLISH_DELAY));
         Assert::AreEqual(1,
                          listener.getCount(),
                          "obs didn't produce state estimate after two sets of data");

--- a/Test/gsapTests/Predictors/EventDrivenPredictorTests.cpp
+++ b/Test/gsapTests/Predictors/EventDrivenPredictorTests.cpp
@@ -14,25 +14,6 @@ using namespace PCOE::Test;
 namespace EventDrivenPredictorTests {
     static const auto PUBLISH_DELAY = std::chrono::milliseconds(5);
 
-    class PredictorListener final : public IMessageProcessor {
-    public:
-        PredictorListener(MessageBus& bus, std::string src) : source(std::move(src)) {
-            bus.subscribe(this, source, MessageId::BatteryEod);
-        }
-
-        void processMessage(const std::shared_ptr<Message>& message) override {
-            ++count;
-        }
-
-        inline std::size_t getCount() const {
-            return count;
-        }
-
-    private:
-        std::string source;
-        std::size_t count = 0;
-    };
-
     void constructor() {
         MessageBus bus;
         TestPrognosticsModel tpm;
@@ -52,7 +33,7 @@ namespace EventDrivenPredictorTests {
         TestLoadEstimator tle;
         const std::string src = "test";
 
-        PredictorListener listener(bus, src);
+        MessageCounter listener(bus, src, MessageId::BatteryEod);
         EventDrivenObserver edObs(bus, std::unique_ptr<Observer>(new TestObserver(&tpm)), src);
         EventDrivenPredictor edPred(bus,
                                     std::unique_ptr<Predictor>(

--- a/Test/gsapTests/Predictors/EventDrivenPredictorTests.cpp
+++ b/Test/gsapTests/Predictors/EventDrivenPredictorTests.cpp
@@ -1,6 +1,8 @@
 // Copyright (c) 2018 United States Government as represented by the
 // Administrator of the National Aeronautics and Space Administration.
 // All Rights Reserved.
+#include <thread>
+
 #include "MockClasses.h"
 #include "Observers/EventDrivenObserver.h"
 #include "Predictors/EventDrivenPredictor.h"
@@ -10,6 +12,8 @@ using namespace PCOE;
 using namespace PCOE::Test;
 
 namespace EventDrivenPredictorTests {
+    static const auto PUBLISH_DELAY = std::chrono::milliseconds(5);
+
     class PredictorListener final : public IMessageProcessor {
     public:
         PredictorListener(MessageBus& bus, std::string src) : source(std::move(src)) {
@@ -62,6 +66,7 @@ namespace EventDrivenPredictorTests {
         bus.publish(std::shared_ptr<Message>(new DoubleMessage(MessageId::TestInput0, src, 0.0)));
         bus.publish(std::shared_ptr<Message>(new DoubleMessage(MessageId::TestInput1, src, 0.0)));
         bus.publish(std::shared_ptr<Message>(new DoubleMessage(MessageId::TestOutput0, src, 0.0)));
+        std::this_thread::sleep_for(std::chrono::milliseconds(PUBLISH_DELAY));
         Assert::AreEqual(0,
                          listener.getCount(),
                          "Predictor produced prediction after one set of data");
@@ -70,6 +75,7 @@ namespace EventDrivenPredictorTests {
         bus.publish(std::shared_ptr<Message>(new DoubleMessage(MessageId::TestInput0, src, 0.0)));
         bus.publish(std::shared_ptr<Message>(new DoubleMessage(MessageId::TestInput1, src, 0.0)));
         bus.publish(std::shared_ptr<Message>(new DoubleMessage(MessageId::TestOutput0, src, 0.0)));
+        std::this_thread::sleep_for(std::chrono::milliseconds(PUBLISH_DELAY));
         Assert::AreEqual(1, listener.getCount(), "Predictor didn't produce prediction");
     }
 }

--- a/Test/gsapTests/main.cpp
+++ b/Test/gsapTests/main.cpp
@@ -255,10 +255,9 @@ int main() {
     context.AddTest("unsubscribe", MessageBusTests::unsubscribe, "MessageBus");
     context.AddTest("unsubscribePartial", MessageBusTests::unsubscribePartial, "MessageBus");
 
-    context.AddTest("construct", MessageWatcherTests::constructor, "MessageWatcher");
-    context.AddTest("allPresent", MessageWatcherTests::allPresent, "MessageWatcher");
-    context.AddTest("reset", MessageWatcherTests::reset, "MessageWatcher");
-    context.AddTest("getValues", MessageWatcherTests::getValues, "MessageWatcher");
+    context.AddTest("Construct", MessageWatcherTests::constructor, "MessageWatcher");
+    context.AddTest("Publish", MessageWatcherTests::publish, "MessageWatcher");
+    context.AddTest("Message Count", MessageWatcherTests::messageCount, "MessageWatcher");
 
     context.AddTest("construct", EventDrivenObserverTests::constructor, "EventDrivenObserver");
     context.AddTest("processMessage",

--- a/inc/Messages/MessageId.h
+++ b/inc/Messages/MessageId.h
@@ -8,8 +8,8 @@
 namespace PCOE {
     /**
      * The set of pre-defined message identifiers. Any integer in the range of
-     * uint64_t may be a valid identifier, any entity dealing with messages should
-     * not treat this list as exhaustive.
+     * uint64_t may be a valid identifier. Any entity dealing with messages
+     * should not treat this list as exhaustive.
      *
      * @author Jason Watkins
      * @since 1.2
@@ -25,6 +25,9 @@ namespace PCOE {
         Centigrade = 0x6272000000000301L,
         Fahrenheit = 0x6272000000000302L,
         ModelStateEstimate = 0x6272000000000400L,
+        ModelStateVector = 0x6272000000000500L,
+        ModelInputVector = 0x6272000000000501L,
+        ModelOutputVector = 0x6272000000000502L,
         TestInput0 = 0x627200000000FE00L,
         TestInput1 = 0x627200000000FE01L,
         TestInput2 = 0x627200000000FE02L,

--- a/inc/Messages/TemplateMessage.h
+++ b/inc/Messages/TemplateMessage.h
@@ -1,0 +1,59 @@
+// Copyright (c) 2018 United States Government as represented by the
+// Administrator of the National Aeronautics and Space Administration.
+// All Rights Reserved.
+#ifndef PCOE_MESSAGES_TEMPLATEMESSAGE_H
+#define PCOE_MESSAGES_TEMPLATEMESSAGE_H
+
+#include "Messages/Message.h"
+
+namespace PCOE {
+    /**
+     * A message that carries a templatized payload.
+     *
+     * @author Jason Watkins
+     * @since 1.2
+     **/
+    template <class T>
+    class TemplateMessage : public Message {
+    public:
+        /**
+         * Constructs a new instance of @{code EmptyMessage}.
+         *
+         * @param id     The id of the message.
+         * @param source The source of the message.
+         * @param v      The value held by the message.
+         **/
+        TemplateMessage(MessageId id, std::string source, T v)
+            : Message(id, source), value(std::move(v)) {}
+
+        /**
+         * Constructs a new instance of @{code EmptyMessage}.
+         *
+         * @param id        The id of the message.
+         * @param source    The source of the message.
+         * @param v      The value held by the message.
+         * @param timestamp The time at which the message or the data contained
+         *                  by the message was generated.
+         **/
+        TemplateMessage(MessageId id, std::string source, T v, time_point timestamp)
+            : Message(id, source, timestamp), value(std::move(v)) {}
+
+        const T& getValue() {
+            return value;
+        }
+
+    protected:
+        std::uint16_t getPayloadSize() const override final {
+            Unimplemented("Can't serialize generic type");
+        }
+
+        void serializePayload(std::ostream&) const override final {
+            Unimplemented("Can't serialize generic type");
+        }
+
+    private:
+        T value;
+    };
+}
+
+#endif

--- a/inc/Observers/EventDrivenObserver.h
+++ b/inc/Observers/EventDrivenObserver.h
@@ -6,11 +6,9 @@
 #include <memory>
 #include <unordered_map>
 
-#include "Messages/DoubleMessage.h"
 #include "Messages/IMessageProcessor.h"
 #include "Messages/MessageBus.h"
 #include "Messages/MessageWatcher.h"
-#include "Messages/UDataVecMessage.h"
 #include "Observers/Observer.h"
 
 namespace PCOE {
@@ -63,6 +61,8 @@ namespace PCOE {
         MessageWatcher<Model::input_type> inputWatcher;
         MessageWatcher<Model::output_type> outputWatcher;
         double latestTimestamp;
+        std::shared_ptr<Message> inputMsg;
+        std::shared_ptr<Message> outputMsg;
     };
 }
 

--- a/src/Observers/EventDrivenObserver.cpp
+++ b/src/Observers/EventDrivenObserver.cpp
@@ -2,6 +2,9 @@
 // Administrator of the National Aeronautics and Space Administration.
 // All Rights Reserved.
 #include "Observers/EventDrivenObserver.h"
+#include "Contracts.h"
+#include "Messages/TemplateMessage.h"
+#include "Messages/UDataVecMessage.h"
 
 namespace PCOE {
     EventDrivenObserver::EventDrivenObserver(MessageBus& messageBus,
@@ -13,20 +16,16 @@ namespace PCOE {
           inputWatcher(bus,
                        source,
                        observer->getModel()->getInputs(),
+                       MessageId::ModelInputVector,
                        observer->getModel()->getInputVector()),
           outputWatcher(bus,
                         source,
                         observer->getModel()->getOutputs(),
+                        MessageId::ModelOutputVector,
                         observer->getModel()->getOutputVector()) {
         Expect(observer, "Observer pointer is empty");
-        auto inputs = observer->getModel()->getInputs();
-        for (auto i : inputs) {
-            bus.subscribe(this, source, i);
-        }
-        auto outputs = observer->getModel()->getOutputs();
-        for (auto o : outputs) {
-            bus.subscribe(this, source, o);
-        }
+        bus.subscribe(this, source, MessageId::ModelInputVector);
+        bus.subscribe(this, source, MessageId::ModelOutputVector);
     }
 
     EventDrivenObserver::~EventDrivenObserver() {
@@ -34,11 +33,24 @@ namespace PCOE {
     }
 
     void EventDrivenObserver::processMessage(const std::shared_ptr<Message>& message) {
-        latestTimestamp = seconds(message->getTimestamp());
+        // TODO (JW): Figure out exactly what needs to be protected by a mutex
+        switch (message->getMessageId()) {
+        case MessageId::ModelInputVector:
+            inputMsg = message;
+            break;
+        case MessageId::ModelOutputVector:
+            outputMsg = message;
+            break;
+        default:
+            Unreachable("Unexpected message type");
+        }
 
-        if (inputWatcher.allPresent() && outputWatcher.allPresent()) {
-            auto u = inputWatcher.getValues();
-            auto z = outputWatcher.getValues();
+        if (inputMsg && outputMsg) {
+            latestTimestamp = seconds(message->getTimestamp());
+            auto typedInMsg = dynamic_cast<TemplateMessage<Model::input_type>*>(inputMsg.get());
+            auto typedOutMsg = dynamic_cast<TemplateMessage<Model::output_type>*>(outputMsg.get());
+            const auto& u = typedInMsg->getValue();
+            const auto& z = typedOutMsg->getValue();
             if (!observer->isInitialized()) {
                 auto x = observer->getModel()->initialize(u, z);
                 observer->initialize(latestTimestamp, x, u);
@@ -50,8 +62,8 @@ namespace PCOE {
                                                                 observer->getStateEstimate());
                 bus.publish(std::shared_ptr<Message>(stateEst));
             }
-            inputWatcher.reset();
-            outputWatcher.reset();
+            inputMsg = nullptr;
+            outputMsg = nullptr;
         }
     }
 }


### PR DESCRIPTION
- Modifies MessageBus to publish messages using `std::async`. This uses the thread calling publish to determine which subscribers to notify, but calls each subscriber's `processMessage` method on its own thread.
- Reworks MessageWatcher to raise messages itself when data is ready, making it thread safe.