### PR TITLE
Message bus

### DIFF
--- a/Test/gsapTests/Messages/MessageWatcherTests.cpp
+++ b/Test/gsapTests/Messages/MessageWatcherTests.cpp
@@ -14,8 +14,6 @@ using namespace PCOE;
 using namespace PCOE::Test;
 
 namespace MessageWatcherTests {
-    static const auto PUBLISH_DELAY = std::chrono::milliseconds(5);
-
     void constructor() {
         MessageBus bus;
         const std::string src = "test";
@@ -36,10 +34,10 @@ namespace MessageWatcherTests {
 
         Assert::AreEqual(0, counter.getCount(), "No data");
         bus.publish(std::shared_ptr<Message>(new DoubleMessage(MessageId::TestInput0, src, 0.0)));
-        std::this_thread::sleep_for(std::chrono::milliseconds(PUBLISH_DELAY));
+        bus.processAll();
         Assert::AreEqual(0, counter.getCount(), "1 input");
         bus.publish(std::shared_ptr<Message>(new DoubleMessage(MessageId::TestInput1, src, 0.0)));
-        std::this_thread::sleep_for(std::chrono::milliseconds(PUBLISH_DELAY));
+        bus.processAll();
         Assert::AreEqual(1, counter.getCount(), "Both inputs");
 
         auto msg = dynamic_cast<VectorMessage<double>*>(counter.getLastMessage().get());
@@ -60,13 +58,13 @@ namespace MessageWatcherTests {
 
         Assert::AreEqual(0, counter.getCount(), "No data");
         bus.publish(std::shared_ptr<Message>(new DoubleMessage(MessageId::TestInput0, src, 1.0)));
-        std::this_thread::sleep_for(std::chrono::milliseconds(PUBLISH_DELAY));
+        bus.processAll();
         Assert::AreEqual(0, counter.getCount(), "Input0 first value");
         bus.publish(std::shared_ptr<Message>(new DoubleMessage(MessageId::TestInput0, src, 2.0)));
-        std::this_thread::sleep_for(std::chrono::milliseconds(PUBLISH_DELAY));
+        bus.processAll();
         Assert::AreEqual(0, counter.getCount(), "Input0 second value");
         bus.publish(std::shared_ptr<Message>(new DoubleMessage(MessageId::TestInput1, src, 3.0)));
-        std::this_thread::sleep_for(std::chrono::milliseconds(PUBLISH_DELAY));
+        bus.processAll();
         Assert::AreEqual(1, counter.getCount(), "1 message per complete set");
 
         auto msg = dynamic_cast<VectorMessage<double>*>(counter.getLastMessage().get());

--- a/Test/gsapTests/Observers/EventDrivenObserverTests.cpp
+++ b/Test/gsapTests/Observers/EventDrivenObserverTests.cpp
@@ -12,7 +12,6 @@ using namespace PCOE;
 using namespace PCOE::Test;
 
 namespace EventDrivenObserverTests {
-    static const auto PUBLISH_DELAY = std::chrono::milliseconds(5);
 
     void constructor() {
         MessageBus bus;
@@ -33,25 +32,25 @@ namespace EventDrivenObserverTests {
 
         Assert::AreEqual(0, listener.getCount(), "obs produced state estimate on construction");
         bus.publish(std::shared_ptr<Message>(new DoubleMessage(MessageId::TestInput0, src, 0.0)));
-        std::this_thread::sleep_for(std::chrono::milliseconds(PUBLISH_DELAY));
+        bus.processAll();
         Assert::AreEqual(0, listener.getCount(), "obs produced state estimate before init (1)");
         bus.publish(std::shared_ptr<Message>(new DoubleMessage(MessageId::TestInput1, src, 0.0)));
-        std::this_thread::sleep_for(std::chrono::milliseconds(PUBLISH_DELAY));
+        bus.processAll();
         Assert::AreEqual(0, listener.getCount(), "obs produced state estimate before init (2)");
         bus.publish(std::shared_ptr<Message>(new DoubleMessage(MessageId::TestOutput0, src, 0.0)));
-        std::this_thread::sleep_for(std::chrono::milliseconds(PUBLISH_DELAY));
+        bus.processAll();
         Assert::AreEqual(0,
                          listener.getCount(),
                          "obs produced state estimate after first set of data");
 
         bus.publish(std::shared_ptr<Message>(new DoubleMessage(MessageId::TestInput0, src, 0.0)));
-        std::this_thread::sleep_for(std::chrono::milliseconds(PUBLISH_DELAY));
+        bus.processAll();
         Assert::AreEqual(0, listener.getCount(), "obs produced state estimate on 1 input");
         bus.publish(std::shared_ptr<Message>(new DoubleMessage(MessageId::TestInput1, src, 0.0)));
-        std::this_thread::sleep_for(std::chrono::milliseconds(PUBLISH_DELAY));
+        bus.processAll();
         Assert::AreEqual(0, listener.getCount(), "obs produced state estimate on 2 inputs");
         bus.publish(std::shared_ptr<Message>(new DoubleMessage(MessageId::TestOutput0, src, 0.0)));
-        std::this_thread::sleep_for(std::chrono::milliseconds(PUBLISH_DELAY));
+        bus.processAll();
         Assert::AreEqual(1,
                          listener.getCount(),
                          "obs didn't produce state estimate after two sets of data");

--- a/Test/gsapTests/Predictors/EventDrivenPredictorTests.cpp
+++ b/Test/gsapTests/Predictors/EventDrivenPredictorTests.cpp
@@ -12,8 +12,6 @@ using namespace PCOE;
 using namespace PCOE::Test;
 
 namespace EventDrivenPredictorTests {
-    static const auto PUBLISH_DELAY = std::chrono::milliseconds(5);
-
     void constructor() {
         MessageBus bus;
         TestPrognosticsModel tpm;
@@ -47,7 +45,7 @@ namespace EventDrivenPredictorTests {
         bus.publish(std::shared_ptr<Message>(new DoubleMessage(MessageId::TestInput0, src, 0.0)));
         bus.publish(std::shared_ptr<Message>(new DoubleMessage(MessageId::TestInput1, src, 0.0)));
         bus.publish(std::shared_ptr<Message>(new DoubleMessage(MessageId::TestOutput0, src, 0.0)));
-        std::this_thread::sleep_for(std::chrono::milliseconds(PUBLISH_DELAY));
+        bus.processAll();
         Assert::AreEqual(0,
                          listener.getCount(),
                          "Predictor produced prediction after one set of data");
@@ -56,7 +54,7 @@ namespace EventDrivenPredictorTests {
         bus.publish(std::shared_ptr<Message>(new DoubleMessage(MessageId::TestInput0, src, 0.0)));
         bus.publish(std::shared_ptr<Message>(new DoubleMessage(MessageId::TestInput1, src, 0.0)));
         bus.publish(std::shared_ptr<Message>(new DoubleMessage(MessageId::TestOutput0, src, 0.0)));
-        std::this_thread::sleep_for(std::chrono::milliseconds(PUBLISH_DELAY));
+        bus.processAll();
         Assert::AreEqual(1, listener.getCount(), "Predictor didn't produce prediction");
     }
 }

--- a/inc/Messages/IMessagePublisher.h
+++ b/inc/Messages/IMessagePublisher.h
@@ -67,7 +67,7 @@ namespace PCOE {
          *                be valid for its lifetime. No attempt is made to manage
          *                the lifetime of the message.
          **/
-        virtual void publish(std::shared_ptr<Message> message) const = 0;
+        virtual void publish(std::shared_ptr<Message> message) = 0;
     };
 }
 #endif

--- a/inc/Messages/MessageBus.h
+++ b/inc/Messages/MessageBus.h
@@ -3,6 +3,7 @@
 // All Rights Reserved.
 #ifndef PCOE_MESSAGES_MESSAGEBUS_H
 #define PCOE_MESSAGES_MESSAGEBUS_H
+#include <future>
 #include <mutex>
 #include <unordered_map>
 #include <vector>
@@ -14,6 +15,36 @@ namespace PCOE {
      * A collection of message subcribers that receive messages based on their
      * message Id's.
      *
+     * For each message that is published, the set of subscribers for that
+     * message is determined, and each subscriber in that set is called in its
+     * own {@code std::async} instance. The behavior of those instances is
+     * controller by the launch policy specified when the message bus is
+     * constructed.
+     *
+     * By default, the {@code std::launch::async} policy is specified, which
+     * launches each {@code std::async} instance on its own thread. In this
+     * mode, no active management of the message bus is required, as message
+     * procesing will proceed automatically on threads managed by the message
+     * bus.
+     *
+     * If {@code std::launch::defered} is specified (either alone or as part of
+     * a bitmask), the end user must periodically call {@code processOne} or
+     * {@code processAll} to ensure that the futures representing calls to
+     * individual subscribers are eventually executed. If
+     * {@code std::launch::defered} is specified alone, the MessageBus will only
+     * make progres when one of the message bus's process methods is called. If
+     * {@code std::launch::defered} is specified as part of a mask that includes
+     * other options, it is implementation-defined whether the bus will process
+     * messages without user intervention.
+     *
+     * The order in which subscribers are notified of new messages is not well
+     * defined. In the case where {@code std::launch::async} is used, all
+     * standard caveats about thread execution ordering apply. In other cases,
+     * the message bus may still make decisions to improve execution efficiency,
+     * such as using a stack to keep track of futures, which would result in a
+     * "depth first" execution of message callback rather than execution in the
+     * order messages are published.
+     *
      * @author Jason Watkins
      * @since 1.2
      **/
@@ -21,8 +52,13 @@ namespace PCOE {
     public:
         /**
          * Constructs a new {@code MessageBus} instance.
+         *
+         * @param launchPolicy The launch policy used when publishing messages.
+         * A new {@code std::async} is created for each subscriber to each
+         * published message using this launch policy.
          **/
-        MessageBus() = default;
+        explicit MessageBus(std::launch launchPolicy = std::launch::async)
+            : launchPolicy(launchPolicy) {}
 
         /**
          * Deleted copy constructor. The {@code MessageBus} may use mutexes
@@ -36,6 +72,23 @@ namespace PCOE {
          * in a default state.
          **/
         MessageBus(MessageBus&&) = default;
+
+        /**
+         * Removes a single message callback from the internal queue and waits
+         * for its completion. Ultimately, this method results in calling
+         * {@code std::future::get}, so the specifics of how that callback is
+         * executed match the implementation details of that method.
+         **/
+        void processOne();
+
+        /**
+         * Removes a message callbacks from the internal queue one at a time and
+         * waits for their completion, continuing until the internal queue is
+         * empty. Ultimately, this method results in calling
+         * {@code std::future::get}, so the specifics of how that callbacks are
+         * executed match the implementation details of that method.
+         **/
+        void processAll();
 
         /**
          * Registers the given consumer to receive messages with the given Id.
@@ -75,14 +128,17 @@ namespace PCOE {
          *
          * @param message A pointer to a message to publish.
          **/
-        void publish(std::shared_ptr<Message> message) const override;
+        void publish(std::shared_ptr<Message> message) override;
 
     private:
         using callback_pair = std::pair<MessageId, IMessageProcessor*>;
         using mutex = std::recursive_mutex;
         using lock_guard = std::lock_guard<mutex>;
+        using unique_lock = std::unique_lock<mutex>;
 
+        const std::launch launchPolicy;
         std::unordered_map<std::string, std::vector<callback_pair>> subscribers;
+        std::vector<std::future<void>> futures;
         mutable mutex m;
     };
 }

--- a/inc/Messages/MessageBus.h
+++ b/inc/Messages/MessageBus.h
@@ -54,8 +54,9 @@ namespace PCOE {
          * Constructs a new {@code MessageBus} instance.
          *
          * @param launchPolicy The launch policy used when publishing messages.
-         * A new {@code std::async} is created for each subscriber to each
-         * published message using this launch policy.
+         *                     A new {@code std::async} is created for each
+         *                     subscriber to each published message using this
+         *                     launch policy.
          **/
         explicit MessageBus(std::launch launchPolicy = std::launch::async)
             : launchPolicy(launchPolicy) {}

--- a/src/Messages/MessageBus.cpp
+++ b/src/Messages/MessageBus.cpp
@@ -32,8 +32,8 @@ namespace PCOE {
             //            recursive and processing one message often leads to
             //            the publishing of further messages.
             lock.unlock();
-
             f.get();
+            lock.lock();
         }
     }
 

--- a/src/Messages/MessageBus.cpp
+++ b/src/Messages/MessageBus.cpp
@@ -8,6 +8,35 @@
 #include "Messages/MessageBus.h"
 
 namespace PCOE {
+    void MessageBus::processOne() {
+        unique_lock lock(m);
+        if (!futures.empty()) {
+            std::future<void> f = std::move(futures.back());
+            futures.pop_back();
+
+            // Note (JW): Unlock before calling get because the mutex is not
+            //            recursive and processing one message often leads to
+            //            the publishing of further messages.
+            lock.unlock();
+            f.get();
+        }
+    }
+
+    void MessageBus::processAll() {
+        unique_lock lock(m);
+        while (!futures.empty()) {
+            std::future<void> f = std::move(futures.back());
+            futures.pop_back();
+
+            // Note (JW): Unlock before calling get because the mutex is not
+            //            recursive and processing one message often leads to
+            //            the publishing of further messages.
+            lock.unlock();
+
+            f.get();
+        }
+    }
+
     void MessageBus::subscribe(IMessageProcessor* consumer, std::string source, MessageId id) {
         lock_guard guard(m);
         subscribers[source].push_back(callback_pair(id, consumer));
@@ -40,8 +69,7 @@ namespace PCOE {
         return f.wait_for(std::chrono::seconds(0)) == std::future_status::ready;
     }
 
-    void MessageBus::publish(std::shared_ptr<Message> message) const {
-        static std::vector<std::future<void>> futures;
+    void MessageBus::publish(std::shared_ptr<Message> message) {
         lock_guard guard(m);
         auto srcSubs = subscribers.find(message->getSource());
         if (srcSubs == subscribers.cend()) {
@@ -50,7 +78,7 @@ namespace PCOE {
 
         for (auto it : (*srcSubs).second) {
             if (it.first == MessageId::All || it.first == message->getMessageId()) {
-                auto f = std::async(std::launch::async,
+                auto f = std::async(launchPolicy,
                                     &IMessageProcessor::processMessage,
                                     it.second,
                                     message);


### PR DESCRIPTION
- Added methods to MessageBus to allow waiting for one/all callbacks to complete
- Added documentation comments explaining how callbacks are processed
- Added optional construction parameter to allow configuration of the execution policy used by `std::async`
- Updated tests to use wait methods instead of sleeping for some time.