### PR TITLE
Added cmake install to the travis script.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -48,7 +48,7 @@ script:
   - mkdir -p bin/testresults
   - pushd build
   - cmake -DCoverage=ON .. $GENERATOR
-  - cmake --build .
+  - cmake --build . --target install
   - popd
   - if [ "$TRAVIS_OS_NAME" == "linux" ] && [ "$COMPENV" == "gcc" ]; then
     pushd coverage;


### PR DESCRIPTION
I thought it would be helpful to have the travis build also run the cmake install target. This will help detect if the cmake install gets broken. By default, a dir called "install" will be created in the top-level cmake binary dir, and the installed files will be copied there. Hopefully that will be out of the way enough to not bother anything else travis is doing. 

I haven't tried running travis on this branch; I did check that cmake syntax is right and it ought to work. You might try it out before accepting the request (if you choose to accept it). 

It would be nicer if there were tests that the install is functioning correctly, but I figured to start with a simple step.

And, now the pull request description is much longer than the code change... 