### PR TITLE
Fix bug in EmptyMessage constructor

### DIFF
--- a/inc/Messages/Message.h
+++ b/inc/Messages/Message.h
@@ -127,8 +127,8 @@ namespace PCOE {
          **/
         EmptyMessage(MessageId id, std::string source, time_point timestamp)
             : Message(id, source, timestamp) {
-            Expect((static_cast<std::uint64_t>(id) & 0x0000300000000000L) > 0,
-                   "Message id is not scalar");
+            Expect((static_cast<std::uint64_t>(id) & 0x0000FF0000000000L) == 0,
+                   "Message id is not empty");
         }
 
     protected:


### PR DESCRIPTION
Oddly enough this wasn't a problem before because a different bug in PaaS was causing empty messages to be parsed as (zero-length) `StringMessages`, which apparently works just fine.