### PR TITLE
Update ProgEvent to be more general

### DIFF
--- a/Test/gsapTests/EventDrivenPrognoserTests.cpp
+++ b/Test/gsapTests/EventDrivenPrognoserTests.cpp
@@ -169,7 +169,7 @@ void testEDPWithMockModel() {
     data[MessageId::TestOutput0].setTime(newTime);
     ProgEvent result = comm.publish(data);
     Assert::AreEqual(result.getState()[0].get(), 1, 1e-6);
-    Assert::AreEqual(result.getStartTime().get(), 1.5, 1e-6);
+    Assert::AreEqual(result.getTOE().get(), 1.5, 1e-6);
 
     // TODO(CT): Test with Config map
     // ModelBasedPrognoser mbp(config);
@@ -196,5 +196,5 @@ void testEDPWithMockModel() {
     data2[MessageId::TestOutput0].setTime(newTime2);
     ProgEvent result2 = comm.publish(data2);
     Assert::AreEqual(result2.getState()[0].get(), 1, 1e-6);
-    Assert::AreEqual(result2.getStartTime().get(), 1.5, 1e-6);
+    Assert::AreEqual(result2.getTOE().get(), 1.5, 1e-6);
 }

--- a/Test/gsapTests/ModelBasedPrognoserTests.cpp
+++ b/Test/gsapTests/ModelBasedPrognoserTests.cpp
@@ -15,7 +15,6 @@
  *     All Rights Reserved.
  */
 
-
 #include <thread>
 
 #include "MockClasses.h"
@@ -47,53 +46,52 @@ void testWithMockModel() {
     config.set("predictor", "Mock");
     config.set("LoadEstimator.Loading", {"1", "2"});
     ModelBasedPrognoser mbp(config);
-    
+
     // Initialize
-    std::map<MessageId, Datum<double> > data;
+    std::map<MessageId, Datum<double>> data;
     data[MessageId::TestInput0] = Datum<double>(1);
     data[MessageId::TestInput1] = Datum<double>(2);
     data[MessageId::TestOutput0] = Datum<double>(3);
     mbp.step(data);
-    
+
     // First Step
     auto newTime = addOneSecond(data[MessageId::TestInput0].getTime());
     data[MessageId::TestInput0].setTime(newTime);
     data[MessageId::TestInput1].setTime(newTime);
     data[MessageId::TestOutput0].setTime(newTime);
     Prediction result = mbp.step(data);
-    
+
     Assert::AreEqual(result.getEvents().size(), 1);
     Assert::AreEqual(result.getEvents()[0].getState()[0].get(), 1, 1e-6);
-    Assert::AreEqual(result.getEvents()[0].getStartTime().get(), 1.5, 1e-6);
+    Assert::AreEqual(result.getEvents()[0].getTOE().get(), 1.5, 1e-6);
     Assert::AreEqual(result.getObservables().size(), 0);
 
-    
     // No time passed
     Prediction result2 = mbp.step(data);
     Assert::AreEqual(result2.getEvents().size(), 0);
     Assert::AreEqual(result2.getObservables().size(), 0);
-    
+
     TestPrognosticsModel model(config);
     TestObserver obs(model, config);
     TestLoadEstimator loadEst(config);
     TestPredictor pred(model, loadEst, TrajectoryService(), config);
     ModelBasedPrognoser mbp2(config);
-    
+
     // Initialize
     mbp2.step(data);
-    
+
     // First Step
     newTime = addOneSecond(data[MessageId::TestInput0].getTime());
     data[MessageId::TestInput0].setTime(newTime);
     data[MessageId::TestInput1].setTime(newTime);
     data[MessageId::TestOutput0].setTime(newTime);
     result = mbp2.step(data);
-    
+
     Assert::AreEqual(result.getEvents().size(), 1);
     Assert::AreEqual(result.getEvents()[0].getState()[0].get(), 1, 1e-6);
-    Assert::AreEqual(result.getEvents()[0].getStartTime().get(), 1.5, 1e-6);
+    Assert::AreEqual(result.getEvents()[0].getTOE().get(), 1.5, 1e-6);
     Assert::AreEqual(result.getObservables().size(), 0);
-    
+
     // No time passed
     result2 = mbp2.step(data);
     Assert::AreEqual(result2.getEvents().size(), 0);

--- a/Test/gsapTests/PredictorTests.cpp
+++ b/Test/gsapTests/PredictorTests.cpp
@@ -80,7 +80,7 @@ void testMonteCarloBatteryPredict() {
     // Compute mean of timeOfEvent and SOC at different time points
     double meanEOD = 0;
     auto& eod = prediction.getEvents()[0];
-    auto& toe = eod.getStartTime();
+    auto& toe = eod.getTOE();
     for (unsigned int i = 0; i < toe.npoints(); i++) {
         meanEOD += toe[i] / toe.npoints();
     }

--- a/Test/gsapTests/Predictors/BatteryResultTests.cpp
+++ b/Test/gsapTests/Predictors/BatteryResultTests.cpp
@@ -201,7 +201,7 @@ namespace BatteryResultTests {
         Assert::AreEqual(7.42001e-12, x_est[7].get(7), 1e-5, "t=1, x_est[7], covariance 7");
         Assert::AreEqual(1.86231e-10, x_est[7].get(8), 1e-5, "t=1, x_est[7], covariance 8");
         auto prediction = predictor.predict(t, x_est);
-        auto event = prediction.getEvents().front().getStartTime().getVec();
+        auto event = prediction.getEvents().front().getTOE().getVec();
         std::sort(event.begin(), event.end());
         Assert::IsTrue(event.front() < 2500, "Lowest event time");
         Assert::IsTrue(event.back() > 2750, "Highest event time floor");
@@ -297,7 +297,7 @@ namespace BatteryResultTests {
         Assert::AreEqual(2.54302e-10, x_est[7].get(8), 1e-5, "t=1, x_est[7], covariance 8");
 
         prediction = predictor.predict(t, x_est);
-        event = prediction.getEvents().front().getStartTime().getVec();
+        event = prediction.getEvents().front().getTOE().getVec();
         std::sort(event.begin(), event.end());
         Assert::IsTrue(event.front() < 2500, "Lowest event time");
         Assert::IsTrue(event.back() > 2750, "Highest event time floor");

--- a/inc/Point4D.h
+++ b/inc/Point4D.h
@@ -60,8 +60,15 @@ namespace PCOE {
         /**
          * Gets the waypoint time.
          **/
-        inline std::chrono::time_point<Clock, Duration> getTime() {
+        inline std::chrono::time_point<Clock, Duration> getTime() const {
             return time;
+        }
+
+        /**
+         * Get the states associated with the point.
+         **/
+        inline const std::vector<double> getStates() const {
+            return states;
         }
 
     private:

--- a/inc/Point4D.h
+++ b/inc/Point4D.h
@@ -33,7 +33,7 @@ namespace PCOE {
                 double lon,
                 double alt,
                 std::chrono::time_point<Clock, Duration> time,
-                std::vector<double> states)
+                std::vector<double> states = {})
             : lat(lat), lon(lon), alt(alt), time(time), states(std::move(states)) {}
 
         /**

--- a/inc/Point4D.h
+++ b/inc/Point4D.h
@@ -1,0 +1,76 @@
+// Copyright (c) 2018 United States Government as represented by the
+// Administrator of the National Aeronautics and Space Administration.
+// All Rights Reserved.
+#ifndef PCOE_POINT4D_H
+#define PCOE_POINT4D_H
+#include <chrono>
+
+namespace PCOE {
+    /**
+     * Represents a point in 4D space
+     *
+     * @author Jason Watkins
+     * @since 1.2
+     **/
+    template <class Clock, class Duration = typename Clock::duration>
+    class Point4D {
+    public:
+        /**
+         * Create a new point at the origin.
+         **/
+        Point4D() = default;
+
+        /**
+         * Create a new point in 4D space
+         *
+         * @param lat    The latitude in degrees.
+         * @param lon    The longitude in degrees.
+         * @param alt    The altitude in meters.
+         * @param time   The time associated with the point.
+         * @param states Information associated with the point
+         */
+        Point4D(double lat,
+                double lon,
+                double alt,
+                std::chrono::time_point<Clock, Duration> time,
+                std::vector<double> states)
+            : lat(lat), lon(lon), alt(alt), time(time), states(std::move(states)) {}
+
+        /**
+         * Gets the waypoint latitude.
+         **/
+        inline double getLatitude() const {
+            return lat;
+        }
+
+        /**
+         * Gets the waypoint longitude.
+         **/
+        inline double getLongitude() const {
+            return lon;
+        }
+
+        /**
+         * Gets the waypoint altitude.
+         **/
+        inline double getAltitude() const {
+            return alt;
+        }
+
+        /**
+         * Gets the waypoint time.
+         **/
+        inline std::chrono::time_point<Clock, Duration> getTime() {
+            return time;
+        }
+
+    private:
+        double lat;
+        double lon;
+        double alt;
+        std::chrono::time_point<Clock, Duration> time;
+        std::vector<double> states;
+    };
+}
+
+#endif

--- a/inc/ProgEvent.h
+++ b/inc/ProgEvent.h
@@ -4,17 +4,19 @@
 #ifndef PCOE_PROGEVENT_H
 #define PCOE_PROGEVENT_H
 #include <string>
+#include <vector>
 
+#include "Messages/MessageClock.h"
 #include "Messages/MessageId.h"
-#include "Point3D.h"
+#include "Point4D.h"
 #include "UData.h"
 
 namespace PCOE {
     /**
-     * Reprsents data associated with a specific prognostic event such as end of
-     * life or end of dischanrge. Data is represented by a start and end time
-     * (which may be the same for an instantaneous event) along with start and
-     * end position and a set of states associated with the event.
+     * Represents data associated with a specific prognostic event such as end
+     * of life or end of dischanrge. Data is represented by a time of event
+     * (with uncertainty) along with a set of 4D points associated with the
+     * event.
      *
      * @remarks
      * In many cases there will be only one event (End of life).
@@ -31,120 +33,24 @@ namespace PCOE {
     class ProgEvent {
     public:
         /**
-         * Creates a new prognostic event with an instantaneous time of event.
+         * Creates a new prognostic event
          *
-         * @remarks
-         * This constructor should be used for events which are instantaneous in
-         * nature and do not have any particular location associated with them.
-         * The event start and end times will be set to {@p toe}, and the start
-         * and end locations will be set to to the origin.
-         *
-         * @param id    The message ID associated with the event.
-         * @param state The state vector associated with the event.
-         * @param toe   The time at which the event will occur.
-         **/
-        ProgEvent(MessageId id, const std::vector<UData>& state, const UData& toe)
-            : ProgEvent(id, state, toe, toe) {}
-
-        /**
-         * Creates a new prognostic event with an instantaneous time of event.
-         *
-         * @remarks
-         * This constructor should be used for events which are instantaneous in
-         * nature, but do have a location associated with them.
-         * The event start and end times will be set to {@p toe}, and the start
-         * and end locations will be set to to {@p pos}.
-         *
-         * @param id    The message ID associated with the event.
-         * @param state The state vector associated with the event.
-         * @param toe   The time at which the event will occur.
-         * @param pos   The location at which the event will occur.
-         **/
-        ProgEvent(MessageId id, const std::vector<UData>& state, const UData& toe, Point3D pos)
-            : ProgEvent(id, state, toe, pos, toe, pos) {}
-
-        /**
-         * Creates a new prognostic event with the specified start and end
-         * times from r-value references.
-         *
-         * @remarks
-         * This constructor should be used for events which are transient in
-         * nature and do not have any particular location associated with them.
-         * The event start and end locations will be set to the origin.
-         *
-         * @param id    The message ID associated with the event.
-         * @param state The state vector associated with the event.
-         * @param start The time at which the event will start.
-         * @param end   The time at which the event will end.
-         **/
-        ProgEvent(MessageId id, std::vector<UData>&& state, UData&& start, UData&& end)
-            : eventId(id), eventState(state), startTime(start), endTime(end) {}
-
-        /**
-         * Creates a new prognostic event with the specified start and end
-         * times.
-         *
-         * @remarks
-         * This constructor should be used for events which are transient in
-         * nature and do not have any particular location associated with them.
-         * The event start and end locations will be set to the origin.
-         *
-         * @param id    The message ID associated with the event.
-         * @param state The state vector associated with the event.
-         * @param start The time at which the event will start.
-         * @param end   The time at which the event will end.
+         * @param id     The message ID associated with the event.
+         * @param state  The state vector associated with the event.
+         * @param toe    The time at which the event will occur.
+         * @param points A set of points associated with the event
+         * @param tag    A tag that provides aditional information about the event.
          **/
         ProgEvent(MessageId id,
-                  const std::vector<UData>& state,
-                  const UData& start,
-                  const UData& end)
-            : eventId(id), eventState(state), startTime(start), endTime(end) {}
-
-        /**
-         * Creates a new prognostic event from r-value references.
-         *
-         * @param id        The message ID associated with the event.
-         * @param state     The state vector associated with the event.
-         * @param startTime The time at which the event will start.
-         * @param startPos  The location at which the event will start.
-         * @param endTime   The time at which the event will end.
-         * @param endPos    The location at which the event will end.
-         **/
-        ProgEvent(MessageId id,
-                  std::vector<UData>&& state,
-                  UData&& startTime,
-                  Point3D startPos,
-                  UData&& endTime,
-                  Point3D endPos)
+                  std::vector<UData> state,
+                  UData toe,
+                  std::vector<Point4D<MessageClock>> points = {},
+                  std::string tag = "")
             : eventId(id),
-              eventState(state),
-              startTime(startTime),
-              startPosition(startPos),
-              endTime(endTime),
-              endPosition(endPos) {}
-
-        /**
-         * Creates a new prognostic event.
-         *
-         * @param id        The message ID associated with the event.
-         * @param state     The state vector associated with the event.
-         * @param startTime The time at which the event will start.
-         * @param startPos  The location at which the event will start.
-         * @param endTime   The time at which the event will end.
-         * @param endPos    The location at which the event will end.
-         **/
-        ProgEvent(MessageId id,
-                  const std::vector<UData>& state,
-                  const UData& startTime,
-                  Point3D startPos,
-                  const UData& endTime,
-                  Point3D endPos)
-            : eventId(id),
-              eventState(state),
-              startTime(startTime),
-              startPosition(startPos),
-              endTime(endTime),
-              endPosition(endPos) {}
+              eventState(std::move(state)),
+              toe(toe),
+              points(std::move(points)),
+              tag(std::move(tag)) {}
 
         /**
          * Gets the message id for the event.
@@ -163,52 +69,30 @@ namespace PCOE {
         /**
          * Gets the start time of the event.
          **/
-        inline const UData& getStartTime() const {
-            return startTime;
+        inline const UData& getTOE() const {
+            return toe;
         }
 
         /**
-         * Gets the start position of the event.
-         *
-         * @remarks
-         * For events that do not map to a particular location, this property
-         * will generally be set to the origin.
+         * Gets the set of state associated with the event.
          **/
-        inline Point3D getStartPosition() const {
-            return startPosition;
+        inline const std::vector<Point4D<MessageClock>> getPoints() const {
+            return points;
         }
 
         /**
-         * Gets the end time of the event.
-         *
-         * @remarks
-         * For events that are instantaneous in nature, this property will
-         * generally be the same as the start time.
+         * Gets the tag associated with the event.
          **/
-        inline const UData& getEndTime() const {
-            return endTime;
-        }
-
-        /**
-         * Gets the end position of the event.
-         *
-         * @remarks
-         * For events that do not map to a particular location, this property
-         * will generally be set to the origin. For events that are
-         * instantaneous in nature, this property will generally be set to the
-         * start position.
-         **/
-        inline Point3D getEndPosition() const {
-            return endPosition;
+        inline const std::string& getTag() const {
+            return tag;
         }
 
     private:
         MessageId eventId;
         std::vector<UData> eventState;
-        UData startTime;
-        Point3D startPosition;
-        UData endTime;
-        Point3D endPosition;
+        UData toe;
+        std::vector<Point4D<MessageClock>> points;
+        std::string tag;
     };
 }
 


### PR DESCRIPTION
It turns out that my recent update to `ProgEvent` was substantially limited in generality. Further discussion on desired outputs for SWS have generated a requirement to store arbitrary amounts of data for a given event. This update rolls back the changes in #100 and makes another attempt to do essentially the same thing in a more general way. This update also includes a string tag for each event to hold data not easily stored in the various numeric values of `ProgEvent`.