### PR TITLE
Make MessageClock::rep signed

### DIFF
--- a/inc/Messages/MessageClock.h
+++ b/inc/Messages/MessageClock.h
@@ -23,7 +23,7 @@ namespace PCOE {
         /**
          * The type used internally to store the clock duration in ticks.
          **/
-        using rep = std::uint64_t;
+        using rep = std::int64_t;
 
         /**
          * A ratio representing the tick period of the clock in seconds.


### PR DESCRIPTION
Although the spec says that clock representations can be unsigned, some hangs have been observed on some OS/compiler combinations that seem to reliably go away when using a signed representation. Since 63 bits still allows us to represent times several hundred-thousand years in the future, I think we can just switch to a signed int64 to avoid the possibility of overflow-related bugs.