### PR TITLE
Added getModel() method

### DIFF
--- a/inc/ModelBasedPrognoser.h
+++ b/inc/ModelBasedPrognoser.h
@@ -55,6 +55,10 @@ namespace PCOE {
          * Produce a new prediction based on the provided data.
          */
         Prediction step(std::map<MessageId, Datum<double>> data);
+
+        const PrognosticsModel& getModel() {
+            return *model.get();
+        }
     };
 }
 

--- a/inc/ModelBasedPrognoser.h
+++ b/inc/ModelBasedPrognoser.h
@@ -57,7 +57,7 @@ namespace PCOE {
         Prediction step(std::map<MessageId, Datum<double>> data);
 
         const PrognosticsModel& getModel() {
-            return *model.get();
+            return *model;
         }
     };
 }


### PR DESCRIPTION
getModel method provides access to the underlying model in the prognoser. This access is required to be able to calculate output parameters from state (which is returned in prediction). 

```c++
auto stateSamples = eod_event.getSystemState()[0]; // Get current system state
std::vector<double> state;
for (auto sample : stateSamples) {
    state.push_back(sample[0]); // Take first sample (could be replaced with logic to get sample corresponding to median SOC
}
auto& model = ((ModelBasedPrognoser *) prognoser.get())->getModel();
auto z = model.outputEqn(now_s.count(), (PrognosticsModel::state_type) state);
std::cout << "\ttemp: " << z[model.indices.output.Tm] << "°C" << std::endl;
```