### PR TITLE
Fix Async Moving Average Load Est Bug

### DIFF
--- a/inc/Loading/LoadListener.h
+++ b/inc/Loading/LoadListener.h
@@ -17,7 +17,7 @@ namespace PCOE {
     class LoadListener: public IMessageProcessor {
     public:
 
-        LoadListener(MessageBus& bus, const std::string& src,LoadEstimator* le) : bus(bus), le(le) {
+        LoadListener(MessageBus& bus, const std::string& src, LoadEstimator& le) : bus(bus), le(le) {
             bus.subscribe(this, src, MessageId::ModelInputVector);
         }
 
@@ -27,15 +27,15 @@ namespace PCOE {
 
         void processMessage(const std::shared_ptr<Message>& message) override {
 
-            if (le->canAddLoad()) {
+            if (le.canAddLoad()) {
                 auto imsgVec = std::dynamic_pointer_cast<DoubleVecMessage, Message>(message);
-                le->addLoad(imsgVec->getValue());
+                le.addLoad(imsgVec->getValue());
             }
         }
 
     private:
         MessageBus& bus;
-        LoadEstimator* le;
+        LoadEstimator& le;
         std::vector<double> measurement;
     };
 

--- a/inc/Loading/LoadListener.h
+++ b/inc/Loading/LoadListener.h
@@ -1,0 +1,44 @@
+// Copyright (c) 2018 United States Government as represented by the
+// Administrator of the National Aeronautics and Space Administration.
+// All Rights Reserved.
+#ifndef LoadListener_h
+#define LoadListener_h
+
+#include <memory>
+#include <string>
+#include <vector>
+
+#include "Loading/LoadEstimator.h"
+#include "Messages/MessageBus.h"
+#include "Messages/VectorMessage.h"
+#include "Models/PrognosticsModel.h"
+
+namespace PCOE {
+    class LoadListener: public IMessageProcessor {
+    public:
+
+        LoadListener(MessageBus& bus, const std::string& src,LoadEstimator* le) : bus(bus), le(le) {
+            bus.subscribe(this, src, MessageId::ModelInputVector);
+        }
+
+        ~LoadListener() {
+            bus.unsubscribe(this);
+        }
+
+        void processMessage(const std::shared_ptr<Message>& message) override {
+
+            if (le->canAddLoad()) {
+                auto imsgVec = std::dynamic_pointer_cast<DoubleVecMessage, Message>(message);
+                le->addLoad(imsgVec->getValue());
+            }
+        }
+
+    private:
+        MessageBus& bus;
+        LoadEstimator* le;
+        std::vector<double> measurement;
+    };
+
+}
+
+#endif /* LoadListener_h */

--- a/inc/Loading/LoadListener.h
+++ b/inc/Loading/LoadListener.h
@@ -1,7 +1,7 @@
-// Copyright (c) 2018 United States Government as represented by the
+// Copyright (c) 2022 United States Government as represented by the
 // Administrator of the National Aeronautics and Space Administration.
 // All Rights Reserved.
-#ifndef LoadListener_h
+#ifndef PCOE_LOADLISTENER_H
 #define LoadListener_h
 
 #include <memory>

--- a/inc/Loading/LoadListener.h
+++ b/inc/Loading/LoadListener.h
@@ -2,7 +2,7 @@
 // Administrator of the National Aeronautics and Space Administration.
 // All Rights Reserved.
 #ifndef PCOE_LOADLISTENER_H
-#define LoadListener_h
+#define PCOE_LOADLISTENER_H
 
 #include <memory>
 #include <string>
@@ -41,4 +41,4 @@ namespace PCOE {
 
 }
 
-#endif /* LoadListener_h */
+#endif /* PCOE_LOADLISTENER_H */

--- a/src/ModelBasedAsyncPrognoserBuilder.cpp
+++ b/src/ModelBasedAsyncPrognoserBuilder.cpp
@@ -6,6 +6,7 @@
 #include "ConfigMap.h"
 #include "Contracts.h"
 #include "Loading/LoadEstimatorFactory.h"
+#include "Loading/LoadListener.h"
 #include "ModelBasedAsyncPrognoserBuilder.h"
 #include "Models/PrognosticsModelFactory.h"
 #include "Observers/AsyncObserver.h"
@@ -125,6 +126,9 @@ namespace PCOE {
             container.addEventListener(
                 new AsyncPredictor(bus, std::move(predictor), sensorSource));
         }
+
+        LoadListener* loadListener = new LoadListener(bus, sensorSource, loadEstimator);
+        container.addEventListener(loadListener);
 
         log.WriteLine(LOG_WARN, MODULE_NAME, "Build complete");
         return container;


### PR DESCRIPTION
This PR fixes a bug where, when operating asynchronously, the MovingAverageLoadEstimator and any other load-based LoadEstimator does not work correctly. This happens because the add_load method is never called. 

The PR fixes the bug by adding a new listener, which listens for the input_vector and adds it to the load estimator. This listener is automatically created by the ModelBasedAsyncPrognoserBuilder