### PR TITLE
Add EOD Voltage Component to SOC Calculation

### DIFF
--- a/examples/async/main.cpp
+++ b/examples/async/main.cpp
@@ -117,12 +117,17 @@ public:
         std::sort(samples.begin(), samples.end());
         double eod_median = samples.at(samples.size() / 2);
 
+        UData currentSOC = eod_event.getState()[0];
+        samples = currentSOC.getVec();
+        std::sort(samples.begin(), samples.end());
+        double soc_median = samples.at(samples.size() / 2);
+
         // Finally, we print the number of milliseconds until EoD
         auto eod_dur = std::chrono::seconds(static_cast<unsigned long>(eod_median));
         auto now =  MessageClock::now();
         auto now_s = duration_cast<std::chrono::seconds>(now.time_since_epoch());
         std::cout << "Predicted median EoD: " << eod_dur.count() << " s (T- "
-                  << (eod_dur-now_s).count() << " s)" << std::endl;
+                  << (eod_dur-now_s).count() << " s)" << " SOC: " << soc_median << std::endl;
     }
 
 private:

--- a/inc/Models/BatteryModel.h
+++ b/inc/Models/BatteryModel.h
@@ -121,6 +121,7 @@ public:
         double tDiffusion;
         double qMobile;
         double An3;
+        double VDropoff;
         
         struct CachedParams {
             double An12_F;


### PR DESCRIPTION
This PR ports over an improvement from ProgPy that updates SOC estimation to include voltage when voltage approaches the VEOD threshold. When this takes effect is configurable (VDropoff

This fixes a phenomenon where RUL is 0, but EOD is not 0. 

See https://github.com/nasa/prog_models/pull/45